### PR TITLE
Loosen version requirements for faraday_middleware

### DIFF
--- a/analytics-ruby.gemspec
+++ b/analytics-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/segmentio/analytics-ruby'
 
   spec.add_dependency 'faraday', ['>= 0.8', '< 0.10']
-  spec.add_dependency 'faraday_middleware', ['~> 0.9.0']
+  spec.add_dependency 'faraday_middleware', ['>= 0.8', '< 0.10']
   spec.add_dependency 'multi_json', ['~> 1.0']
 
   spec.add_development_dependency('rake')


### PR DESCRIPTION
Just to be sure I ran the specs against all the versions list here

![](http://f.cl.ly/items/3k2330283m151s2C0U18/Screen%20Shot%202013-03-19%20at%209.17.41%20AM.png)
