### PR TITLE
Move class methods into ClassMethods module for better extensibility.

### DIFF
--- a/lib/analytics-ruby.rb
+++ b/lib/analytics-ruby.rb
@@ -2,23 +2,23 @@ require 'analytics-ruby/version'
 require 'analytics-ruby/client'
 
 module AnalyticsRuby
+  module ClassMethods
+    # By default use a single client for the module
+    def init(options = {})
+      @client = AnalyticsRuby::Client.new(options)
+    end
 
-  # By default use a single client for the module
-  def self.init(options = {})
-    @client = AnalyticsRuby::Client.new(options)
+    def track(options)
+      return false unless @client
+      @client.track(options)
+    end
+
+    def identify(options)
+      return false unless @client
+      @client.identify(options)
+    end
   end
-
-  def self.track(options)
-    return false unless @client
-    @client.track(options)
-  end
-
-  def self.identify(options)
-    return false unless @client
-    @client.identify(options)
-  end
-
-
+  extend ClassMethods
 end
 
 # Alias for AnalyticsRuby


### PR DESCRIPTION
My uses case is something along the lines of this.

``` ruby
# /lib/segment_io.rb
module SegmentIO
  CONFIG = OpenStruct.new(enabled: false)
  extend AnalyticsRuby::ClassMethods

  def self.config(&block)
    yield CONFIG if block_given?
    SegmentIO.init(secret: CONFIG.secret) if CONFIG.secret && CONFIG.enabled
  end
end

# /config/initializers/segment_io.rb

SegmentIO.config do |config|
  config.enabled  = true
  config.secret   = ENV["SEGMENT_PRODUCTION_SECRET"] || 'dev-test-secret'
  config.api_key  = ENV["SEGMENT_PRODUCTION_APIKEY"] || 'dev-test-apikey'
end

# call it server side like.
SegmentIO.track(user_id: '53', event: 'Test Event')

# Also reference the api_key client side for javascript
# <% SegmentIO::CONFIG.api_key %>
```

This pull is to support the...

``` ruby
...
extend AnalyticsRuby::ClassMethods
...
```

...bit above.
