### PR TITLE
Allow init/track/identify/alias to accept strings as keys.

### DIFF
--- a/lib/analytics-ruby/client.rb
+++ b/lib/analytics-ruby/client.rb
@@ -4,6 +4,7 @@ require 'thread'
 require 'analytics-ruby/defaults'
 require 'analytics-ruby/consumer'
 require 'analytics-ruby/request'
+require 'analytics-ruby/util'
 
 module AnalyticsRuby
 
@@ -16,6 +17,8 @@ module AnalyticsRuby
     #           :max_queue_size - Fixnum of the max calls to remain queued (optional)
     #           :on_error       - Proc which handles error calls from the API
     def initialize(options = {})
+
+      Util.symbolize_keys!(options)
 
       @queue = Queue.new
       @secret = options[:secret]
@@ -48,6 +51,8 @@ module AnalyticsRuby
     def track(options)
 
       check_secret
+
+      Util.symbolize_keys!(options)
 
       event = options[:event]
       user_id = options[:user_id].to_s
@@ -85,6 +90,8 @@ module AnalyticsRuby
 
       check_secret
 
+      Util.symbolize_keys!(options)
+
       user_id = options[:user_id].to_s
       traits = options[:traits] || {}
       timestamp = options[:timestamp] || Time.new
@@ -114,6 +121,8 @@ module AnalyticsRuby
     def alias(options)
 
       check_secret
+
+      Util.symbolize_keys!(options)
 
       from = options[:from].to_s
       to = options[:to].to_s

--- a/lib/analytics-ruby/consumer.rb
+++ b/lib/analytics-ruby/consumer.rb
@@ -1,6 +1,7 @@
 
 require 'analytics-ruby/defaults'
 require 'analytics-ruby/request'
+require 'analytics-ruby/util'
 
 module AnalyticsRuby
 
@@ -18,6 +19,8 @@ module AnalyticsRuby
     #           on_error   - Proc of what to do on an error
     #
     def initialize(queue, secret, options = {})
+      Util.symbolize_keys!(options)
+
       @queue = queue
       @secret = secret
       @batch_size = options[:batch_size] || AnalyticsRuby::Defaults::Queue::BATCH_SIZE

--- a/lib/analytics-ruby/util.rb
+++ b/lib/analytics-ruby/util.rb
@@ -1,0 +1,13 @@
+module Util
+  def self.symbolize_keys(hash)
+    hash.inject({}) { |memo, (k,v)| memo[k.to_sym] = v; memo }
+  end
+
+  def self.symbolize_keys!(hash)
+    hash.replace symbolize_keys(hash)
+  end
+
+  def self.stringify_keys(hash)
+    hash.inject({}) { |memo, (k,v)| memo[k.to_s] = v; memo }
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -13,6 +13,10 @@ describe Analytics::Client do
     it 'should not error if a secret is supplied' do
       Analytics::Client.new secret: AnalyticsHelpers::SECRET
     end
+
+    it 'should not error if a secret is supplied as a string' do
+      Analytics::Client.new 'secret' => AnalyticsHelpers::SECRET
+    end
   end
 
   describe '#track' do
@@ -38,6 +42,10 @@ describe Analytics::Client do
     it 'should not error with the required options' do
       @client.track AnalyticsHelpers::Queued::TRACK
     end
+
+    it 'should not error when given string keys' do
+      @client.track Util.stringify_keys(AnalyticsHelpers::Queued::TRACK)
+    end
   end
 
 
@@ -53,6 +61,10 @@ describe Analytics::Client do
 
     it 'should not error with the required options' do
       @client.identify AnalyticsHelpers::Queued::IDENTIFY
+    end
+
+    it 'should not error with the required options as strings' do
+      @client.identify Util.stringify_keys(AnalyticsHelpers::Queued::IDENTIFY)
     end
   end
 
@@ -71,6 +83,10 @@ describe Analytics::Client do
 
     it 'should not error with the required options' do
       @client.alias AnalyticsHelpers::ALIAS
+    end
+
+    it 'should not error with the required options as strings' do
+      @client.alias Util.stringify_keys(AnalyticsHelpers::ALIAS)
     end
   end
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -4,6 +4,14 @@ require 'spec_helper'
 
 describe Analytics::Consumer do
 
+  describe "#init" do
+    it 'accepts string keys' do
+      queue = Queue.new
+      consumer = Analytics::Consumer.new(queue, 'secret', 'batch_size' => 100)
+      consumer.instance_variable_get(:@batch_size).should == 100
+    end
+  end
+
   describe '#flush' do
 
     it 'should not error if the endpoint is unreachable' do


### PR DESCRIPTION
This addresses Issue #13.

I will not be offended if you decide this behavior should be handled client-side.
