### PR TITLE
isoify dates for the group method

### DIFF
--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -162,6 +162,7 @@ module Segment
         context = options[:context] || {}
 
         fail ArgumentError, '.traits must be a hash' unless traits.is_a? Hash
+        isoify_dates! traits
 
         check_presence! group_id, 'group_id'
         check_timestamp! timestamp

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -140,6 +140,7 @@ module Segment
       describe '#group' do
         before :all do
           @client = Client.new :write_key => WRITE_KEY
+          @queue = @client.instance_variable_get :@queue
         end
 
         it 'should error without group_id' do
@@ -156,6 +157,20 @@ module Segment
 
         it 'should not error with the required options as strings' do
           @client.group Utils.stringify_keys(Queued::GROUP)
+        end
+
+        it 'should convert Time traits into iso8601 format' do
+          @client.group({
+            :user_id => 'user',
+            :group_id => 'group',
+            :traits => {
+              :time => Time.utc(2013),
+              :nottime => 'x'
+            }
+          })
+          message = @queue.pop
+          message[:traits][:time].should == '2013-01-01T00:00:00Z'
+          message[:traits][:nottime].should == 'x'
         end
       end
 


### PR DESCRIPTION
This make sure dates are converted in the group method just like they are in identify.  This is an attempt to fix #56 but it doesn't look like the whole solution since Intercom is still getting bad data.  Is there a server side fix that also need to be done?
