### PR TITLE
Fixed timestamp rounding issue

### DIFF
--- a/lib/segment/analytics/utils.rb
+++ b/lib/segment/analytics/utils.rb
@@ -50,8 +50,10 @@ module Segment
 
       def datetime_in_iso8601 datetime
         case datetime
-        when Time, DateTime
+        when Time
             time_in_iso8601 datetime
+        when DateTime
+            time_in_iso8601 datetime.to_time
         when Date
           date_in_iso8601 datetime
         else
@@ -59,7 +61,7 @@ module Segment
         end
       end
 
-      def time_in_iso8601 time, fraction_digits = 0
+      def time_in_iso8601 time, fraction_digits = 3
         fraction = if fraction_digits > 0
                      (".%06i" % time.usec)[0, fraction_digits + 1]
                    end

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -42,7 +42,7 @@ module Segment
         end
 
         it 'should use the timestamp given' do
-          time = Time.parse("1990-07-16 13:30:00 UTC")
+          time = Time.parse("1990-07-16 13:30:00.123 UTC")
 
           @client.track({
             :event => 'testing the timestamp',
@@ -78,9 +78,9 @@ module Segment
             }
           })
           message = @queue.pop
-          message[:properties][:time].should == '2013-01-01T00:00:00Z'
-          message[:properties][:time_with_zone].should == '2013-01-01T00:00:00Z'
-          message[:properties][:date_time].should == '2013-01-01T00:00:00Z'
+          message[:properties][:time].should == '2013-01-01T00:00:00.000Z'
+          message[:properties][:time_with_zone].should == '2013-01-01T00:00:00.000Z'
+          message[:properties][:date_time].should == '2013-01-01T00:00:00.000Z'
           message[:properties][:date].should == '2013-01-01'
           message[:properties][:nottime].should == 'x'
         end
@@ -119,9 +119,9 @@ module Segment
             }
           })
           message = @queue.pop
-          message[:traits][:time].should == '2013-01-01T00:00:00Z'
-          message[:traits][:time_with_zone].should == '2013-01-01T00:00:00Z'
-          message[:traits][:date_time].should == '2013-01-01T00:00:00Z'
+          message[:traits][:time].should == '2013-01-01T00:00:00.000Z'
+          message[:traits][:time_with_zone].should == '2013-01-01T00:00:00.000Z'
+          message[:traits][:date_time].should == '2013-01-01T00:00:00.000Z'
           message[:traits][:date].should == '2013-01-01'
           message[:traits][:nottime].should == 'x'
         end
@@ -188,9 +188,9 @@ module Segment
             }
           })
           message = @queue.pop
-          message[:traits][:time].should == '2013-01-01T00:00:00Z'
-          message[:traits][:time_with_zone].should == '2013-01-01T00:00:00Z'
-          message[:traits][:date_time].should == '2013-01-01T00:00:00Z'
+          message[:traits][:time].should == '2013-01-01T00:00:00.000Z'
+          message[:traits][:time_with_zone].should == '2013-01-01T00:00:00.000Z'
+          message[:traits][:date_time].should == '2013-01-01T00:00:00.000Z'
           message[:traits][:date].should == '2013-01-01'
           message[:traits][:nottime].should == 'x'
         end


### PR DESCRIPTION
Adjusted util method to round to 3 millisecs by default and not 0
