### PR TITLE
Allow no write_key if requests are stubbed

### DIFF
--- a/lib/segment/analytics.rb
+++ b/lib/segment/analytics.rb
@@ -10,7 +10,7 @@ require 'segment/analytics/logging'
 module Segment
   class Analytics
     def initialize options = {}
-      Request.stub = options[:stub]
+      Request.stub_requests = options[:stub]
       @client = Segment::Analytics::Client.new options
     end
 

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -316,8 +316,11 @@ module Segment
         context[:library] =  { :name => "analytics-ruby", :version => Segment::Analytics::VERSION.to_s }
       end
 
-      # private: Checks that the write_key is properly initialized
+      # private: Checks that the write_key is properly initialized.
+      # Short-circuit the test if Requests are being stubbed anyways since it
+      # wont matter.
       def check_write_key!
+        return if Request.stub_requests
         fail ArgumentError, 'Write key must be initialized' if @write_key.nil?
       end
 

--- a/lib/segment/analytics/request.rb
+++ b/lib/segment/analytics/request.rb
@@ -45,7 +45,7 @@ module Segment
           request = Net::HTTP::Post.new(@path, headers)
           request.basic_auth write_key, nil
 
-          if self.class.stub
+          if self.class.stub_requests
             status = 200
             error = nil
             logger.debug "stubbed request to #{@path}: write key = #{write_key}, payload = #{payload}"
@@ -71,10 +71,10 @@ module Segment
       end
 
       class << self
-        attr_accessor :stub
+        attr_accessor :stub_requests
 
-        def stub
-          @stub || ENV['STUB']
+        def stub_requests
+          @stub_requests || ENV['STUB']
         end
       end
     end

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -8,6 +8,11 @@ module Segment
           expect { Client.new }.to raise_error(ArgumentError)
         end
 
+        it 'should not error if a write key is not supplied but Request.stub_requests is true' do
+          Request.stub(:stub_requests).and_return true
+          expect { Client.new }.to_not raise_error
+        end
+
         it 'should not error if a write_key is supplied' do
           Client.new :write_key => WRITE_KEY
         end


### PR DESCRIPTION
Why bother importing "fake" write_keys into my test environment if the requests are going to be stubbed anyways?  This just makes more of a hassle for developers that use dot_env or figaro.
