### PR TITLE
Fix issue w/ JSON.generate, use .to_json instead

### DIFF
--- a/lib/segment/analytics/request.rb
+++ b/lib/segment/analytics/request.rb
@@ -41,7 +41,7 @@ module Segment
         backoff = @backoff
         headers = { 'Content-Type' => 'application/json', 'accept' => 'application/json' }
         begin
-          payload = JSON.generate :sentAt => datetime_in_iso8601(Time.new), :batch => batch
+          payload = {:sentAt => datetime_in_iso8601(Time.new), :batch => batch}.to_json
           request = Net::HTTP::Post.new(@path, headers)
           request.basic_auth write_key, nil
 


### PR DESCRIPTION
We kept seeing this issue when passing in full ActiveRecord objects as additional parameters to our track calls. 

https://github.com/intridea/multi_json/issues/86

The `JSON.generate` serialization fell down in many cases. Changing to `.to_json` fixed the issue for us.
