### PR TITLE
Update spec suite

### DIFF
--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -113,7 +113,7 @@ module Segment
           end.to_not raise_error
         end
 
-        it 'should convert time and date traits into iso8601 format' do
+        it 'converts time and date traits into iso8601 format' do
           client.identify({
             :user_id => 'user',
             :traits => {

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -3,37 +3,39 @@ require 'spec_helper'
 module Segment
   class Analytics
     describe Client do
+      let(:client) { Client.new :write_key => WRITE_KEY }
+      let(:queue) { client.instance_variable_get :@queue }
+
       describe '#initialize' do
-        it 'should error if no write_key is supplied' do
+        it 'errors if no write_key is supplied' do
           expect { Client.new }.to raise_error(ArgumentError)
         end
 
-        it 'should not error if a write_key is supplied' do
-          Client.new :write_key => WRITE_KEY
+        it 'does not error if a write_key is supplied' do
+          expect do
+            Client.new :write_key => WRITE_KEY
+          end.to_not raise_error
         end
 
-        it 'should not error if a write_key is supplied as a string' do
-          Client.new 'write_key' => WRITE_KEY
+        it 'does not error if a write_key is supplied as a string' do
+          expect do
+            Client.new 'write_key' => WRITE_KEY
+          end.to_not raise_error
         end
       end
 
       describe '#track' do
-        before(:all) do
-          @client = Client.new :write_key => WRITE_KEY
-          @queue = @client.instance_variable_get :@queue
+        it 'errors without an event' do
+          expect { client.track(:user_id => 'user') }.to raise_error(ArgumentError)
         end
 
-        it 'should error without an event' do
-          expect { @client.track(:user_id => 'user') }.to raise_error(ArgumentError)
+        it 'errors without a user_id' do
+          expect { client.track(:event => 'Event') }.to raise_error(ArgumentError)
         end
 
-        it 'should error without a user_id' do
-          expect { @client.track(:event => 'Event') }.to raise_error(ArgumentError)
-        end
-
-        it 'should error if properties is not a hash' do
+        it 'errors if properties is not a hash' do
           expect {
-            @client.track({
+            client.track({
               :user_id => 'user',
               :event => 'Event',
               :properties => [1,2,3]
@@ -41,32 +43,36 @@ module Segment
           }.to raise_error(ArgumentError)
         end
 
-        it 'should use the timestamp given' do
+        it 'uses the timestamp given' do
           time = Time.parse("1990-07-16 13:30:00.123 UTC")
 
-          @client.track({
+          client.track({
             :event => 'testing the timestamp',
             :user_id => 'joe',
             :timestamp => time
           })
 
-          msg = @queue.pop
+          msg = queue.pop
 
-          Time.parse(msg[:timestamp]).should == time
+          expect(Time.parse(msg[:timestamp])).to eq(time)
         end
 
-        it 'should not error with the required options' do
-          @client.track Queued::TRACK
-          @queue.pop
+        it 'does not error with the required options' do
+          expect do
+            client.track Queued::TRACK
+            queue.pop
+          end.to_not raise_error
         end
 
-        it 'should not error when given string keys' do
-          @client.track Utils.stringify_keys(Queued::TRACK)
-          @queue.pop
+        it 'does not error when given string keys' do
+          expect do
+            client.track Utils.stringify_keys(Queued::TRACK)
+            queue.pop
+          end.to_not raise_error
         end
 
-        it 'should convert time and date traits into iso8601 format' do
-          @client.track({
+        it 'converts time and date traits into iso8601 format' do
+          client.track({
             :user_id => 'user',
             :event => 'Event',
             :properties => {
@@ -77,38 +83,38 @@ module Segment
               :nottime => 'x'
             }
           })
-          message = @queue.pop
-          message[:properties][:time].should == '2013-01-01T00:00:00.000Z'
-          message[:properties][:time_with_zone].should == '2013-01-01T00:00:00.000Z'
-          message[:properties][:date_time].should == '2013-01-01T00:00:00.000Z'
-          message[:properties][:date].should == '2013-01-01'
-          message[:properties][:nottime].should == 'x'
+          message = queue.pop
+
+          expect(message[:properties][:time]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:properties][:time_with_zone]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:properties][:date_time]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:properties][:date]).to eq('2013-01-01')
+          expect(message[:properties][:nottime]).to eq('x')
         end
       end
 
 
       describe '#identify' do
-        before(:all) do
-          @client = Client.new :write_key => WRITE_KEY
-          @queue = @client.instance_variable_get :@queue
+        it 'errors without any user id' do
+          expect { client.identify({}) }.to raise_error(ArgumentError)
         end
 
-        it 'should error without any user id' do
-          expect { @client.identify({}) }.to raise_error(ArgumentError)
+        it 'does not error with the required options' do
+          expect do
+            client.identify Queued::IDENTIFY
+            queue.pop
+          end.to_not raise_error
         end
 
-        it 'should not error with the required options' do
-          @client.identify Queued::IDENTIFY
-          @queue.pop
-        end
-
-        it 'should not error with the required options as strings' do
-          @client.identify Utils.stringify_keys(Queued::IDENTIFY)
-          @queue.pop
+        it 'does not error with the required options as strings' do
+          expect do
+            client.identify Utils.stringify_keys(Queued::IDENTIFY)
+            queue.pop
+          end.to_not raise_error
         end
 
         it 'should convert time and date traits into iso8601 format' do
-          @client.identify({
+          client.identify({
             :user_id => 'user',
             :traits => {
               :time => Time.utc(2013),
@@ -118,65 +124,60 @@ module Segment
               :nottime => 'x'
             }
           })
-          message = @queue.pop
-          message[:traits][:time].should == '2013-01-01T00:00:00.000Z'
-          message[:traits][:time_with_zone].should == '2013-01-01T00:00:00.000Z'
-          message[:traits][:date_time].should == '2013-01-01T00:00:00.000Z'
-          message[:traits][:date].should == '2013-01-01'
-          message[:traits][:nottime].should == 'x'
+
+          message = queue.pop
+
+          expect(message[:traits][:time]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:traits][:time_with_zone]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:traits][:date_time]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:traits][:date]).to eq('2013-01-01')
+          expect(message[:traits][:nottime]).to eq('x')
         end
       end
 
       describe '#alias' do
-        before :all do
-          @client = Client.new :write_key => WRITE_KEY
+        it 'errors without from' do
+          expect { client.alias :user_id => 1234 }.to raise_error(ArgumentError)
         end
 
-        it 'should error without from' do
-          expect { @client.alias :user_id => 1234 }.to raise_error(ArgumentError)
+        it 'errors without to' do
+          expect { client.alias :previous_id => 1234 }.to raise_error(ArgumentError)
         end
 
-        it 'should error without to' do
-          expect { @client.alias :previous_id => 1234 }.to raise_error(ArgumentError)
+        it 'does not error with the required options' do
+          expect { client.alias ALIAS }.to_not raise_error
         end
 
-        it 'should not error with the required options' do
-          @client.alias ALIAS
-        end
-
-        it 'should not error with the required options as strings' do
-          @client.alias Utils.stringify_keys(ALIAS)
+        it 'does not error with the required options as strings' do
+          expect do
+            client.alias Utils.stringify_keys(ALIAS)
+          end.to_not raise_error
         end
       end
 
       describe '#group' do
-        before :all do
-          @client = Client.new :write_key => WRITE_KEY
-          @queue = @client.instance_variable_get :@queue
+        after do
+          client.flush
         end
 
-        after :each do
-          @client.flush
+        it 'errors without group_id' do
+          expect { client.group :user_id => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should error without group_id' do
-          expect { @client.group :user_id => 'foo' }.to raise_error(ArgumentError)
+        it 'errors without user_id' do
+          expect { client.group :group_id => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should error without user_id' do
-          expect { @client.group :group_id => 'foo' }.to raise_error(ArgumentError)
+        it 'does not error with the required options' do
+          client.group Queued::GROUP
         end
 
-        it 'should not error with the required options' do
-          @client.group Queued::GROUP
+        it 'does not error with the required options as strings' do
+          client.group Utils.stringify_keys(Queued::GROUP)
         end
 
-        it 'should not error with the required options as strings' do
-          @client.group Utils.stringify_keys(Queued::GROUP)
-        end
-
-        it 'should convert time and date traits into iso8601 format' do
-          @client.identify({
+        it 'converts time and date traits into iso8601 format' do
+          client.identify({
             :user_id => 'user',
             :group_id => 'group',
             :traits => {
@@ -187,70 +188,65 @@ module Segment
               :nottime => 'x'
             }
           })
-          message = @queue.pop
-          message[:traits][:time].should == '2013-01-01T00:00:00.000Z'
-          message[:traits][:time_with_zone].should == '2013-01-01T00:00:00.000Z'
-          message[:traits][:date_time].should == '2013-01-01T00:00:00.000Z'
-          message[:traits][:date].should == '2013-01-01'
-          message[:traits][:nottime].should == 'x'
+
+          message = queue.pop
+
+          expect(message[:traits][:time]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:traits][:time_with_zone]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:traits][:date_time]).to eq('2013-01-01T00:00:00.000Z')
+          expect(message[:traits][:date]).to eq('2013-01-01')
+          expect(message[:traits][:nottime]).to eq('x')
         end
       end
 
       describe '#page' do
-        before :all do
-          @client = Client.new :write_key => WRITE_KEY
+        it 'errors without user_id' do
+          expect { client.page :name => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should error without user_id' do
-          expect { @client.page :name => 'foo' }.to raise_error(ArgumentError)
+        it 'does not error with the required options' do
+          expect { client.page Queued::PAGE }.to_not raise_error
         end
 
-        it 'should not error with the required options' do
-          @client.page Queued::PAGE
-        end
-
-        it 'should not error with the required options as strings' do
-          @client.page Utils.stringify_keys(Queued::PAGE)
+        it 'does not error with the required options as strings' do
+          expect do
+            client.page Utils.stringify_keys(Queued::PAGE)
+          end.to_not raise_error
         end
       end
 
       describe '#screen' do
-        before :all do
-          @client = Client.new :write_key => WRITE_KEY
+        it 'errors without user_id' do
+          expect { client.screen :name => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should error without user_id' do
-          expect { @client.screen :name => 'foo' }.to raise_error(ArgumentError)
+        it 'does not error with the required options' do
+          expect { client.screen Queued::SCREEN }.to_not raise_error
         end
 
-        it 'should not error with the required options' do
-          @client.screen Queued::SCREEN
-        end
-
-        it 'should not error with the required options as strings' do
-          @client.screen Utils.stringify_keys(Queued::SCREEN)
+        it 'does not error with the required options as strings' do
+          expect do
+            client.screen Utils.stringify_keys(Queued::SCREEN)
+          end.to_not raise_error
         end
       end
 
       describe '#flush' do
-        before(:all) do
-          @client = Client.new :write_key => WRITE_KEY
+        it 'waits for the queue to finish on a flush' do
+          client.identify Queued::IDENTIFY
+          client.track Queued::TRACK
+          client.flush
+
+          expect(client.queued_messages).to eq(0)
         end
 
-        it 'should wait for the queue to finish on a flush' do
-          @client.identify Queued::IDENTIFY
-          @client.track Queued::TRACK
-          @client.flush
-          @client.queued_messages.should == 0
-        end
-
-        it 'should complete when the process forks' do
-          @client.identify Queued::IDENTIFY
+        it 'completes when the process forks' do
+          client.identify Queued::IDENTIFY
 
           Process.fork do
-            @client.track Queued::TRACK
-            @client.flush
-            @client.queued_messages.should == 0
+            client.track Queued::TRACK
+            client.flush
+            expect(client.queued_messages).to eq(0)
           end
 
           Process.wait
@@ -258,31 +254,46 @@ module Segment
       end
 
       context 'common' do
-        check_property = proc { |msg, k, v| msg[k] && msg[k].should == v }
+        check_property = proc { |msg, k, v| msg[k] && msg[k] == v }
 
-        before(:all) do
-          @client = Client.new :write_key => WRITE_KEY
-          @queue = @client.instance_variable_get :@queue
-        end
+        let(:data) { { :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :event => "coco barked", :name => "coco" } }
 
+        it 'does not convert ids given as fixnums to strings' do
+          [:track, :screen, :page, :identify].each do |s|
+            client.send(s, data)
+            message = queue.pop(true)
 
-        it 'should not convert ids given as fixnums to strings' do
-          [:track, :screen, :page, :group, :identify, :alias].each do |s|
-            @client.send s, :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :event => "coco barked", :name => "coco"
-            message = @queue.pop(true)
-            check_property.call(message, :userId, 1)
-            check_property.call(message, :groupId, 2)
-            check_property.call(message, :previousId, 3)
-            check_property.call(message, :anonymousId, 4)
+            expect(check_property.call(message, :userId, 1)).to eq(true)
+            expect(check_property.call(message, :anonymousId, 4)).to eq(true)
           end
         end
 
-        it 'should send integrations' do
+        context 'group' do
+          it 'does not convert ids given as fixnums to strings' do
+            client.group(data)
+            message = queue.pop(true)
+
+            expect(check_property.call(message, :userId, 1)).to eq(true)
+            expect(check_property.call(message, :groupId, 2)).to eq(true)
+          end
+        end
+
+        context 'alias' do
+          it 'does not convert ids given as fixnums to strings' do
+            client.alias(data)
+            message = queue.pop(true)
+
+            expect(check_property.call(message, :userId, 1)).to eq(true)
+            expect(check_property.call(message, :previousId, 3)).to eq(true)
+          end
+        end
+
+        it 'sends integrations' do
           [:track, :screen, :page, :group, :identify, :alias].each do |s|
-            @client.send s, :integrations => { :All => true, :Salesforce => false }, :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :event => "coco barked", :name => "coco"
-            message = @queue.pop(true)
-            message[:integrations][:All].should be_true
-            message[:integrations][:Salesforce].should be_false
+            client.send s, :integrations => { :All => true, :Salesforce => false }, :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :event => "coco barked", :name => "coco"
+            message = queue.pop(true)
+            expect(message[:integrations][:All]).to eq(true)
+            expect(message[:integrations][:Salesforce]).to eq(false)
           end
         end
       end

--- a/spec/segment/analytics_spec.rb
+++ b/spec/segment/analytics_spec.rb
@@ -6,88 +6,99 @@ module Segment
       let(:analytics) { Segment::Analytics.new :write_key => WRITE_KEY, :stub => true }
 
       describe '#track' do
-        it 'should error without an event' do
+        it 'errors without an event' do
           expect { analytics.track(:user_id => 'user') }.to raise_error(ArgumentError)
         end
 
-        it 'should error without a user_id' do
+        it 'errors without a user_id' do
           expect { analytics.track(:event => 'Event') }.to raise_error(ArgumentError)
         end
 
-        it 'should not error with the required options' do
-          analytics.track Queued::TRACK
-          sleep(1)
+        it 'does not error with the required options' do
+          expect do
+            analytics.track Queued::TRACK
+            sleep(1)
+          end.to_not raise_error
         end
       end
 
-
       describe '#identify' do
-        it 'should error without a user_id' do
+        it 'errors without a user_id' do
           expect { analytics.identify :traits => {} }.to raise_error(ArgumentError)
         end
 
-        it 'should not error with the required options' do
+        it 'does not error with the required options' do
           analytics.identify Queued::IDENTIFY
           sleep(1)
         end
       end
 
       describe '#alias' do
-        it 'should error without from' do
+        it 'errors without from' do
           expect { analytics.alias :user_id => 1234 }.to raise_error(ArgumentError)
         end
 
-        it 'should error without to' do
+        it 'errors without to' do
           expect { analytics.alias :previous_id => 1234 }.to raise_error(ArgumentError)
         end
 
-        it 'should not error with the required options' do
-          analytics.alias ALIAS
-          sleep(1)
+        it 'does not error with the required options' do
+          expect do
+            analytics.alias ALIAS
+            sleep(1)
+          end.to_not raise_error
         end
       end
 
       describe '#group' do
-        it 'should error without group_id' do
+        it 'errors without group_id' do
           expect { analytics.group :user_id => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should error without user_id or anonymous_id' do
+        it 'errors without user_id or anonymous_id' do
           expect { analytics.group :group_id => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should not error with the required options' do
-          analytics.group Queued::GROUP
-          sleep(1)
+        it 'does not error with the required options' do
+          expect do
+            analytics.group Queued::GROUP
+            sleep(1)
+          end.to_not raise_error
         end
       end
 
       describe '#page' do
-        it 'should error without user_id or anonymous_id' do
+        it 'errors without user_id or anonymous_id' do
           expect { analytics.page :name => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should not error with the required options' do
-          analytics.page Queued::PAGE
-          sleep(1)
+        it 'does not error with the required options' do
+          expect do
+            analytics.page Queued::PAGE
+            sleep(1)
+          end.to_not raise_error
         end
       end
 
       describe '#screen' do
-        it 'should error without user_id or anonymous_id' do
+        it 'errors without user_id or anonymous_id' do
           expect { analytics.screen :name => 'foo' }.to raise_error(ArgumentError)
         end
 
-        it 'should not error with the required options' do
-          analytics.screen Queued::SCREEN
-          sleep(1)
+        it 'does not error with the required options' do
+          expect do
+            analytics.screen Queued::SCREEN
+            sleep(1)
+          end.to_not raise_error
         end
       end
 
       describe '#flush' do
-        it 'should flush without error' do
-          analytics.identify Queued::IDENTIFY
-          analytics.flush
+        it 'flushes without error' do
+          expect do
+            analytics.identify Queued::IDENTIFY
+            analytics.flush
+          end.to_not raise_error
         end
       end
     end


### PR DESCRIPTION
@travisjeffery @calvinfo 

Even though the development dependency of this is not yet rspec 3, these changes will make the transition much easier when neeeded :)

Summary of Changes:

1. Following the [better specs](http://betterspecs.org/) guidelines, I changed the assertion text in specs to remove the word "should". This allows the specs to describe in more natural language what they expect to happen.

2. In a number of specs, I added an explicit assertion for the lack of an error. This will better communicate that an error was raised when not expected instead of simply that an error was raised. 

3. Instance variables were removed in favour of `let` assignments.

4. The `client_spec` had a group of specs named `#common` which had some short circuit logic to only assert for certain keys of the grouping. I have moved out the two special cases `group` and `alias` into their own specs for readability and comprehensiveness. Hopefully this will avoid a false positive for skipping assertions.

5. One thing I did not fix but noticed was that the `#is_requesting?` spec in `worker_spec` seems to intermittently fail (most likely due to the threading and `eventually` block). I am sure you are aware of this but it might need a second look.