### PR TITLE
Add support for optional explicit `messageId`.

### DIFF
--- a/lib/segment/analytics.rb
+++ b/lib/segment/analytics.rb
@@ -10,7 +10,7 @@ require 'segment/analytics/logging'
 module Segment
   class Analytics
     def initialize options = {}
-      Request.stub = options[:stub]
+      Request.stub = options[:stub] if options.has_key?(:stub)
       @client = Segment::Analytics::Client.new options
     end
 

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -52,6 +52,7 @@ module Segment
       #           :properties   - Hash of event properties. (optional)
       #           :timestamp    - Time of when the event occurred. (optional)
       #           :user_id      - String of the user id.
+      #           :message_id   - String of the message id that uniquely identified a message across the API. (optional)
       def track attrs
         symbolize_keys! attrs
         check_user_id! attrs
@@ -60,6 +61,7 @@ module Segment
         properties = attrs[:properties] || {}
         timestamp = attrs[:timestamp] || Time.new
         context = attrs[:context] || {}
+        message_id = attrs[:message_id].to_s if attrs[:message_id]
 
         check_timestamp! timestamp
 
@@ -76,10 +78,11 @@ module Segment
           :event => event,
           :userId => attrs[:user_id],
           :anonymousId => attrs[:anonymous_id],
-          :context =>  context,
+          :context => context,
           :options => attrs[:options],
           :integrations => attrs[:integrations],
           :properties => properties,
+          :messageId => message_id,
           :timestamp => datetime_in_iso8601(timestamp),
           :type => 'track'
         })
@@ -95,6 +98,7 @@ module Segment
       #           :timestamp    - Time of when the event occurred. (optional)
       #           :traits       - Hash of user traits. (optional)
       #           :user_id      - String of the user id
+      #           :message_id   - String of the message id that uniquely identified a message across the API. (optional)
       def identify attrs
         symbolize_keys! attrs
         check_user_id! attrs
@@ -102,6 +106,7 @@ module Segment
         traits = attrs[:traits] || {}
         timestamp = attrs[:timestamp] || Time.new
         context = attrs[:context] || {}
+        message_id = attrs[:message_id].to_s if attrs[:message_id]
 
         check_timestamp! timestamp
 
@@ -117,6 +122,7 @@ module Segment
           :context => context,
           :traits => traits,
           :options => attrs[:options],
+          :messageId => message_id,
           :timestamp => datetime_in_iso8601(timestamp),
           :type => 'identify'
         })
@@ -131,6 +137,7 @@ module Segment
       #           :previous_id - String of the id to alias from
       #           :timestamp   - Time of when the alias occured (optional)
       #           :user_id     - String of the id to alias to
+      #           :message_id   - String of the message id that uniquely identified a message across the API. (optional)
       def alias(attrs)
         symbolize_keys! attrs
 
@@ -138,6 +145,7 @@ module Segment
         to = attrs[:user_id]
         timestamp = attrs[:timestamp] || Time.new
         context = attrs[:context] || {}
+        message_id = attrs[:message_id].to_s if attrs[:message_id]
 
         check_presence! from, 'previous_id'
         check_presence! to, 'user_id'
@@ -150,6 +158,7 @@ module Segment
           :integrations => attrs[:integrations],
           :context => context,
           :options => attrs[:options],
+          :messageId => message_id,
           :timestamp => datetime_in_iso8601(timestamp),
           :type => 'alias'
         })
@@ -164,6 +173,7 @@ module Segment
       #           :previous_id  - String of the id to alias from
       #           :timestamp    - Time of when the alias occured (optional)
       #           :user_id      - String of the id to alias to
+      #           :message_id   - String of the message id that uniquely identified a message across the API. (optional)
       def group(attrs)
         symbolize_keys! attrs
         check_user_id! attrs
@@ -173,6 +183,7 @@ module Segment
         traits = attrs[:traits] || {}
         timestamp = attrs[:timestamp] || Time.new
         context = attrs[:context] || {}
+        message_id = attrs[:message_id].to_s if attrs[:message_id]
 
         fail ArgumentError, '.traits must be a hash' unless traits.is_a? Hash
         isoify_dates! traits
@@ -188,6 +199,7 @@ module Segment
           :integrations => attrs[:integrations],
           :options => attrs[:options],
           :context => context,
+          :messageId => message_id,
           :timestamp => datetime_in_iso8601(timestamp),
           :type => 'group'
         })
@@ -205,6 +217,7 @@ module Segment
       #           :properties   - Hash of page properties (optional)
       #           :timestamp    - Time of when the pageview occured (optional)
       #           :user_id      - String of the id to alias from
+      #           :message_id   - String of the message id that uniquely identified a message across the API. (optional)
       def page(attrs)
         symbolize_keys! attrs
         check_user_id! attrs
@@ -213,6 +226,7 @@ module Segment
         properties = attrs[:properties] || {}
         timestamp = attrs[:timestamp] || Time.new
         context = attrs[:context] || {}
+        message_id = attrs[:message_id].to_s if attrs[:message_id]
 
         fail ArgumentError, '.properties must be a hash' unless properties.is_a? Hash
         isoify_dates! properties
@@ -229,6 +243,7 @@ module Segment
           :integrations => attrs[:integrations],
           :options => attrs[:options],
           :context => context,
+          :messageId => message_id,
           :timestamp => datetime_in_iso8601(timestamp),
           :type => 'page'
         })
@@ -253,6 +268,7 @@ module Segment
         properties = attrs[:properties] || {}
         timestamp = attrs[:timestamp] || Time.new
         context = attrs[:context] || {}
+        message_id = attrs[:message_id].to_s if attrs[:message_id]
 
         fail ArgumentError, '.properties must be a hash' unless properties.is_a? Hash
         isoify_dates! properties
@@ -269,6 +285,7 @@ module Segment
           :options => attrs[:options],
           :integrations => attrs[:integrations],
           :context => context,
+          :messageId => message_id,
           :timestamp => timestamp.iso8601,
           :type => 'screen'
         })
@@ -288,7 +305,7 @@ module Segment
       # returns Boolean of whether the item was added to the queue.
       def enqueue(action)
         # add our request id for tracing purposes
-        action[:messageId] = uid
+        action[:messageId] ||= uid
         unless queue_full = @queue.length >= @max_queue_size
           ensure_worker_running
           @queue << action

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -256,7 +256,7 @@ module Segment
       context 'common' do
         check_property = proc { |msg, k, v| msg[k] && msg[k] == v }
 
-        let(:data) { { :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :event => "coco barked", :name => "coco" } }
+        let(:data) { { :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :message_id => 5, :event => "coco barked", :name => "coco" } }
 
         it 'does not convert ids given as fixnums to strings' do
           [:track, :screen, :page, :identify].each do |s|
@@ -265,6 +265,15 @@ module Segment
 
             expect(check_property.call(message, :userId, 1)).to eq(true)
             expect(check_property.call(message, :anonymousId, 4)).to eq(true)
+          end
+        end
+
+        it 'converts message id to string' do
+          [:track, :screen, :page, :group, :identify, :alias].each do |s|
+            client.send(s, data)
+            message = queue.pop(true)
+
+            expect(check_property.call(message, :messageId, '5')).to eq(true)
           end
         end
 


### PR DESCRIPTION
As per [the documentation](https://segment.com/docs/spec/common/) and [my question on twitter](http://twitter.com/f2prateek/status/677535905372966913), here’s a patch that makes it possible to pacify explicit message identifiers.