### PR TITLE
Ensure the error handler is called before Client#flush finishes.

### DIFF
--- a/lib/segment/analytics/worker.rb
+++ b/lib/segment/analytics/worker.rb
@@ -44,9 +44,9 @@ module Segment
 
           res = Request.new.post @write_key, @batch
 
-          @lock.synchronize { @batch.clear }
-
           @on_error.call res.status, res.error unless res.status == 200
+
+          @lock.synchronize { @batch.clear }
         end
       end
 


### PR DESCRIPTION
A simplification of my needs is:

```ruby
success = true
on_error = Proc.new { success = false }

analytics = Segment::Analytics.new(write_key: 'secret', on_error: on_error)
# submit a bunch of data...
analytics.flush

if success
  # delete data now that it has definitively sent to Segment
end
```

This PR ensures that `Client#flush` does not ever return _before_ the error handler has been called, otherwise that might open up the possibility for me to delete the data even though an error occurred.