### PR TITLE
Only catch and block for retries on specific exceptions

### DIFF
--- a/lib/segment/analytics/request.rb
+++ b/lib/segment/analytics/request.rb
@@ -55,7 +55,7 @@ module Segment
             body = JSON.parse(res.body)
             error = body["error"]
           end
-        rescue Exception => e
+        rescue JSON::ParserError, Net::ReadTimeout, Net::OpenTimeout, EOFError => e
           unless (remaining_retries -=1).zero?
             sleep(backoff)
             retry


### PR DESCRIPTION
Since this retry blocks a thread, if unintended exceptions are caught and batches are not being used, a thread pool can quickly be exhausted, leading to cascading failures.

Also addresses https://github.com/segmentio/analytics-ruby/issues/72.
