### PR TITLE
Fix failing specs in Ruby 2.2.3

### DIFF
--- a/lib/segment/analytics/utils.rb
+++ b/lib/segment/analytics/utils.rb
@@ -63,7 +63,7 @@ module Segment
 
       def time_in_iso8601 time, fraction_digits = 3
         fraction = if fraction_digits > 0
-                     (".%06i" % time.usec)[0, fraction_digits + 1]
+                     (".%06i" % time.utc.usec)[0, fraction_digits + 1]
                    end
 
         "#{time.strftime("%Y-%m-%dT%H:%M:%S")}#{fraction}#{formatted_offset(time, true, 'Z')}"


### PR DESCRIPTION
- While running specs in Ruby 2.2.3, three of specs failed. All of them
  are related to DateTime usages. Converting the time to UTC helps those specs
  to pass.
- Update spec code to use new RSpec syntax
