### PR TITLE
Add log messages for enqueuing messages

### DIFF
--- a/lib/segment/analytics/utils.rb
+++ b/lib/segment/analytics/utils.rb
@@ -63,7 +63,7 @@ module Segment
 
       def time_in_iso8601 time, fraction_digits = 3
         fraction = if fraction_digits > 0
-                     (".%06i" % time.usec)[0, fraction_digits + 1]
+                     (".%06i" % time.utc.usec)[0, fraction_digits + 1]
                    end
 
         "#{time.strftime("%Y-%m-%dT%H:%M:%S")}#{fraction}#{formatted_offset(time, true, 'Z')}"

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -306,6 +306,20 @@ module Segment
           end
         end
       end
+
+      context 'logging' do
+        describe '#enqueue' do
+          it 'logs warns and errors on queue being full' do
+            client = Client.new :write_key => WRITE_KEY, max_queue_size: 5
+            expect(client.logger).to receive(:warn).with(/Queue is .* full/)
+            expect(client.logger).to receive(:error).at_least(:once).with(/Queue is full, dropping events/)
+
+            10.times do
+              client.track({ :user_id => 'user', :event => "Event" })
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds logging to message enqueuing when queue is full hinting users that events are being dropped.
