### PR TITLE
Enforces userId anonId requirement

### DIFF
--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -355,7 +355,7 @@ module Segment
       end
 
       def check_user_id! attrs
-        fail ArgumentError, 'Must supply either user_id or anonymous_id' unless attrs[:user_id] || attrs[:anonymous_id]
+        fail ArgumentError, 'Must supply either user_id or anonymous_id' unless attrs[:user_id].present? || attrs[:anonymous_id].present?
       end
 
       def ensure_worker_running

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -99,6 +99,10 @@ module Segment
           expect { client.identify({}) }.to raise_error(ArgumentError)
         end
 
+        it 'errors on an empty string' do
+          expect { client.identify({ :user_id => '' }) }.to raise_error(ArgumentError)
+        end
+
         it 'does not error with the required options' do
           expect do
             client.identify Queued::IDENTIFY

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -103,7 +103,7 @@ module Segment
           expect { client.identify({ :anonymous_id => '' }) }.to raise_error(ArgumentError)
         end
 
-        it 'errors on an empty string' do
+        it 'errors on an empty user_id' do
           expect { client.identify({ :user_id => '' }) }.to raise_error(ArgumentError)
         end
 

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -99,6 +99,10 @@ module Segment
           expect { client.identify({}) }.to raise_error(ArgumentError)
         end
 
+        it 'errors on an empty anonymous_id' do
+          expect { client.identify({ :anonymous_id => '' }) }.to raise_error(ArgumentError)
+        end
+
         it 'errors on an empty string' do
           expect { client.identify({ :user_id => '' }) }.to raise_error(ArgumentError)
         end


### PR DESCRIPTION
addresses https://github.com/segmentio/analytics-ruby/issues/93

jira https://segment.atlassian.net/browse/EPD-376

why isn't there a test already in place for this condition?
@dominicbarnes @hankim813 @segmentio/platform-integrations 