### PR TITLE
removed gem wrong and created helper for  method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+
+before_install:
+  - gem install bundler

--- a/analytics-ruby.gemspec
+++ b/analytics-ruby.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'commander', '~> 4.4'
 
   spec.add_development_dependency 'rake', '~> 10.3'
-  spec.add_development_dependency 'wrong', '~> 0.0'
   spec.add_development_dependency 'rspec', '~> 2.0'
   spec.add_development_dependency 'tzinfo', '1.2.1'
   spec.add_development_dependency 'activesupport', '>= 3.0.0', '<4.0.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,7 +83,7 @@ end
 # end
 
 module AsyncHelper
-  def eventually(options: {})
+  def eventually(options = {})
     timeout = options[:timeout] || 2
     interval = options[:interval] || 0.1
     time_limit = Time.now + timeout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
 require 'segment/analytics'
-require 'wrong'
 require 'active_support/time'
-
-include Wrong
 
 # Setting timezone for ActiveSupport::TimeWithZone to UTC
 Time.zone = 'UTC'
@@ -79,3 +76,27 @@ module Segment
     end
   end
 end
+
+# usage:
+# it "should return a result of 5" do
+#   eventually(options: {timeout: 1}) { long_running_thing.result.should eq(5) }
+# end
+
+module AsyncHelper
+  def eventually(options: {})
+    timeout = options[:timeout] || 2
+    interval = options[:interval] || 0.1
+    time_limit = Time.now + timeout
+    loop do
+      begin
+        yield
+      rescue => error
+      end
+      return if error.nil?
+      raise error if Time.now >= time_limit
+      sleep interval
+    end
+  end
+end
+
+include AsyncHelper


### PR DESCRIPTION
This PR includes : 
- fix of this error : https://travis-ci.org/segmentio/analytics-ruby/jobs/173137566

- removed gem `wrong` as version 0.3.3 didn't have method `eventually`. However latest version `0.7.1` has this method introduced. 

- To fix this error I have created helper in spec_helper.rb which accepts Hash as parameter and check for expected value.

- To fix error with ruby 1.9.3 about `NoMethodError: undefined method 'spec' for nil:NilClass`, modified travis.yml and added to install latest bundler  https://travis-ci.org/segmentio/analytics-ruby/jobs/221370817#L182

@benjaminhoffman