### PR TITLE
Implement respond_to_missing? instead of respond_to?

### DIFF
--- a/lib/segment/analytics.rb
+++ b/lib/segment/analytics.rb
@@ -22,7 +22,7 @@ module Segment
       end
     end
 
-    def respond_to? method_name, include_private = false
+    def respond_to_missing?(method_name, include_private = false)
       @client.respond_to?(method_name) || super
     end
 

--- a/spec/segment/analytics_spec.rb
+++ b/spec/segment/analytics_spec.rb
@@ -101,6 +101,20 @@ module Segment
           end.to_not raise_error
         end
       end
+
+      describe '#respond_to?' do
+        it 'responds to all public instance methods of Segment::Analytics::Client' do
+          expect(analytics).to respond_to(*Segment::Analytics::Client.public_instance_methods(false))
+        end
+      end
+
+      describe '#method' do
+        Segment::Analytics::Client.public_instance_methods(false).each do |public_method|
+          it "returns a Method object with '#{public_method}' as argument" do
+            expect(analytics.method(public_method).class).to eq(Method)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hi! 

This is an small change to fix a problem I found in your `Segment::Analytics` class. overriding  `respond_to_missing` instead of `respond_to?` is considered a better practice.

If you override `respond_to?`, Methods like: `method` are going to lie when the parameter is a ghost method name, it is going to raise an exception. This problem generates a problem when mocking `Segment::Analytics` methods in rspec tests, because for most people an instance of `Segment::Analytics` responds to track, so it can be mocked, but, with the actual implementation it raise and exception.

Best regards,
Daniel.