### PR TITLE
Add user agent header with library name/version

### DIFF
--- a/lib/segment/analytics/defaults.rb
+++ b/lib/segment/analytics/defaults.rb
@@ -7,7 +7,8 @@ module Segment
         PATH = '/v1/import'
         SSL = true
         HEADERS = { 'Accept' => 'application/json',
-                    'Content-Type' => 'application/json' }
+                    'Content-Type' => 'application/json',
+                    'User-Agent' => "analytics-ruby/#{Analytics::VERSION}" }
         RETRIES = 10
       end
 

--- a/spec/segment/analytics/request_spec.rb
+++ b/spec/segment/analytics/request_spec.rb
@@ -118,7 +118,8 @@ module Segment
           path = subject.instance_variable_get(:@path)
           default_headers = {
             'Content-Type' => 'application/json',
-            'Accept' => 'application/json'
+            'Accept' => 'application/json',
+            'User-Agent' => "analytics-ruby/#{Analytics::VERSION}"
           }
           expect(Net::HTTP::Post).to receive(:new).with(
             path, default_headers


### PR DESCRIPTION
The format used in this PR is `analytics-ruby/1.2.3`, as mentioned in https://tools.ietf.org/html/rfc7231#section-5.5.3. 

I noticed that the format is inconsistent across other client libraries:

- [analytics-go](https://github.com/segmentio/analytics-go/blob/bdb0aeca8a993b292b85c9ec17b5ce0ff81848c8/analytics.go#L308) uses `analytics-go (version: 1.2.3)`
- [analytics-node](https://github.com/segmentio/analytics-node/blob/master/index.js#L231) uses `analytics-node 1.2.3`

Let me know if this looks good, and I'll send PRs for the other libraries