### PR TITLE
Spawn worker after adding item to queue

### DIFF
--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -309,8 +309,8 @@ module Segment
         action[:messageId] ||= uid
 
         if @queue.length < @max_queue_size
-          ensure_worker_running
           @queue << action
+          ensure_worker_running
 
           true
         else


### PR DESCRIPTION
When calling `enqueue()` an event is sometimes not sent out immediately. I noticed this when working on the E2E tests. The library seemed to be exhibiting an intermittent lag between sending events.

It's hard to write a test for this since the order of statements is indeterminate, but here are a few screenshots of logs I added to the existing code to demonstrate the issue: 

![screen shot 2017-12-14 at 2 57 10 pm](https://user-images.githubusercontent.com/3893573/33985400-80f1bc12-e0e0-11e7-95a3-e17998f76a8e.png)

The first example is one where the event is sent out immediately. In the second example, the worker has exited by the time the item is queued, and hence it isn't sent out immediately. This bug doesn't have serious effects though, events are always eventually sent out by the next `enqueue`/`flush`.