### PR TITLE
Add logging if queue is full

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 223
+  Max: 229
 
 # Offense count: 1
 Metrics/CyclomaticComplexity:

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -1,13 +1,16 @@
 require 'thread'
 require 'time'
+
+require 'segment/analytics/defaults'
+require 'segment/analytics/logging'
 require 'segment/analytics/utils'
 require 'segment/analytics/worker'
-require 'segment/analytics/defaults'
 
 module Segment
   class Analytics
     class Client
       include Segment::Analytics::Utils
+      include Segment::Analytics::Logging
 
       # public: Creates a new client
       #
@@ -314,7 +317,12 @@ module Segment
 
           true
         else
-          false # Queue is full
+          logger.warn(
+            'Queue is full, dropping events. The :max_queue_size ' \
+            'configuration parameter can be increased to prevent this from ' \
+            'happening.'
+          )
+          false
         end
       end
 

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -275,6 +275,16 @@ module Segment
           end
         end
 
+        it 'returns false if queue is full' do
+          client.instance_variable_set(:@max_queue_size, 1)
+
+          [:track, :screen, :page, :group, :identify, :alias].each do |s|
+            expect(client.send(s, data)).to eq(true)
+            expect(client.send(s, data)).to eq(false) # Queue is full
+            queue.pop(true)
+          end
+        end
+
         it 'converts message id to string' do
           [:track, :screen, :page, :group, :identify, :alias].each do |s|
             client.send(s, data)


### PR DESCRIPTION
https://github.com/segmentio/analytics-ruby/pull/108, with two changes: 

- Only logs when the queue is indeed full, not when it is almost full
- The log is a warning instead of an error. The return value (true/false), and the `queued_messages` value can be used to recover from this situation.