### PR TITLE
Update analytics binary to be compatible with the testing harness.

### DIFF
--- a/bin/analytics
+++ b/bin/analytics
@@ -10,143 +10,84 @@ program :name, 'simulator.rb'
 program :version, '0.0.1'
 program :description, 'scripting simulator'
 
-# use an env var for write key, instead of a flag
-Analytics = Segment::Analytics.new({
-  write_key: ENV['SEGMENT_WRITE_KEY'],
-  on_error: Proc.new { |status, msg| print msg }
-})
-
-def toObject(str)
-  return JSON.parse(str)
+def json_hash(str)
+  if str
+    return JSON.parse(str)
+  end
 end
 
-# high level
-# analytics <method> [options]
-# SEGMENT_WRITE_KEY=<write_key> ./analytics.rb <method> [options]
-# SEGMENT_WRITE_KEY=<write_key> ./analytics.rb track --event testing --user 1234 --anonymous 567 --properties '{"hello": "goodbye"}' --context '{"slow":"poke"}'
+# analytics -method=<method> -segment-write-key=<segmentWriteKey> [options]
 
+default_command :send
 
+command :send do |c|
+  c.description = 'send a segment message'
 
-# track
-command :track do |c|
-  c.description = 'track a user event'
-  c.option '--user <id>', String, 'the user id to send the event as'
-  c.option '--event <event>', String, 'the event name to send with the event'
-  c.option '--anonymous <id>', String, 'the anonymous user id to send the event as'
-  c.option '--properties <data>', 'the event properties to send (JSON-encoded)'
-  c.option '--context <data>', 'additional context for the event (JSON-encoded)'
+  c.option '--writeKey=<writeKey>', String, 'the Segment writeKey'
+  c.option '--type=<type>', String, 'The Segment message type'
+
+  c.option '--userId=<userId>', String, 'the user id to send the event as'
+  c.option '--anonymousId=<anonymousId>', String, 'the anonymous user id to send the event as'
+  c.option '--context=<context>', 'additional context for the event (JSON-encoded)'
+
+  c.option '--event=<event>', String, 'the event name to send with the event'
+  c.option '--properties=<properties>', 'the event properties to send (JSON-encoded)'
+
+  c.option '--name=<name>', 'name of the screen or page to send with the message'
+
+  c.option '--traits=<traits>', 'the identify/group traits to send (JSON-encoded)'
+
+  c.option '--groupId=<groupId>', String, 'the group id'
 
   c.action do |args, options|
-    Analytics.track({
-      user_id: options.user,
-      event: options.event,
-      anonymous_id: options.anonymous,
-      properties: toObject(options.properties),
-      context: toObject(options.context)
-       })
+    Analytics = Segment::Analytics.new({
+      write_key: options.writeKey,
+      on_error: Proc.new { |status, msg| print msg }
+    })
+
+    case options.type
+    when "track"
+      Analytics.track({
+        user_id: options.userId,
+        event: options.event,
+        anonymous_id: options.anonymousId,
+        properties: json_hash(options.properties),
+        context: json_hash(options.context)
+      })
+    when "page"
+      Analytics.page({
+        user_id: options.userId,
+        anonymous_id: options.anonymousId,
+        name: options.name,
+        properties: json_hash(options.properties),
+        context: json_hash(options.context)
+      })
+    when "screen"
+      Analytics.screen({
+        user_id: options.userId,
+        anonymous_id: options.anonymousId,
+        name: option.name,
+        traits: json_hash(options.traits),
+        properties: json_hash(option.properties)
+      })
+    when "identify"
+      Analytics.identify({
+        user_id: options.userId,
+        anonymous_id: options.anonymousId,
+        traits: json_hash(options.traits),
+        context: json_hash(options.context)
+      })
+    when "group"
+      Analytics.group({
+        user_id: options.userId,
+        anonymous_id: options.anonymousId,
+        group_id: options.groupId,
+        traits: json_hash(options.traits),
+        context: json_hash(options.context)
+      })
+    else
+      raise "Invalid Message Type #{options.type}"
+    end
     Analytics.flush
   end
-
 end
-
-# page
-command :page do |c|
-  c.description = 'track a page view'
-  c.option '--user <id>', String, 'the user id to send the event as'
-  c.option '--anonymous <id>', String, 'the anonymous user id to send the event as'
-  c.option '--name <name>', String, 'the page name'
-  c.option '--properties <data>', 'the event properties to send (JSON-encoded)'
-  c.option '--context <data>', 'additional context for the event (JSON-encoded)'
-  c.option '--category <category>', 'the category of the page'
-  c.action do |args, options|
-    Analytics.page({
-      user_id: options.user,
-      anonymous_id: options.anonymous,
-      name: options.name,
-      properties: toObject(options.properties),
-      context: toObject(options.context),
-      category: options.category
-       })
-    Analytics.flush
-  end
-
-end
-
-# identify
-command :identify do |c|
-  c.description = 'identify a user'
-  c.option '--user <id>', String, 'the user id to send the event as'
-  c.option '--anonymous <id>', String, 'the anonymous user id to send the event as'
-  c.option '--traits <data>', String, 'the user traits to send (JSON-encoded)'
-  c.option '--context <data>', 'additional context for the event (JSON-encoded)'
-  c.action do |args, options|
-    Analytics.identify({
-      user_id: options.user,
-      anonymous_id: options.anonymous,
-      traits: toObject(options.traits),
-      context: toObject(options.context)
-       })
-    Analytics.flush
-  end
-
-end
-
-# screen
-command :screen do |c|
-  c.description = 'track a screen view'
-  c.option '--user <id>', String, 'the user id to send the event as'
-  c.option '--anonymous <id>', String, 'the anonymous user id to send the event as'
-  c.option '--name <name>', String, 'the screen name'
-  c.option '--properties <data>', String, 'the event properties to send (JSON-encoded)'
-  c.option '--context <data>', 'additional context for the event (JSON-encoded)'
-  c.action do |args, options|
-    Analytics.identify({
-      user_id: options.user,
-      anonymous_id: options.anonymous,
-      name: option.name,
-      traits: toObject(options.traits),
-      properties: toObject(option.properties),
-      context: toObject(options.context)
-       })
-    Analytics.flush
-  end
-
-end
-
-
-# group
-command :group do |c|
-  c.description = 'identify a group of users'
-  c.option '--user <id>', String, 'the user id to send the event as'
-  c.option '--anonymous <id>', String, 'the anonymous user id to send the event as'
-  c.option '--group <id>', String, 'the group id to associate this user with'
-  c.option '--traits <data>', String, 'attributes about the group (JSON-encoded)'
-  c.option '--context <data>', 'additional context for the event (JSON-encoded)'
-  c.action do |args, options|
-    Analytics.group({
-      user_id: options.user,
-      anonymous_id: options.anonymous,
-      group_id: options.group,
-      traits: toObject(options.traits),
-      context: toObject(options.context)
-       })
-    Analytics.flush
-  end
-
-end
-
-# alias
-command :alias do |c|
-  c.description = 'remap a user to a new id'
-  c.option '--user <id>', String, 'the user id to send the event as'
-  c.option '--previous <id>', String, 'the previous user id (to add the alias for)'
-  c.action do |args, options|
-    Analytics.alias({
-      user_id: options.user,
-      previous_id: options.previous
-       })
-    Analytics.flush
-  end
-
-end
-


### PR DESCRIPTION
https://paper.dropbox.com/doc/Libraries-End-to-End-Testing-Harness-dnotyIVIGYR7lnO1LcZtM#:uid=457845578223014078216812&h2=Contract

Main changes are:
* writeKey is a flag instead of an env var
* method is a flag, instead of a top level command
* context, properties, traits etc are optional

Also fixed a bug with `screen` in the binary. Previously it was invoking `identify` instead of screen.