### PR TITLE
require version first as it is used in the defaults now

### DIFF
--- a/lib/segment/analytics.rb
+++ b/lib/segment/analytics.rb
@@ -1,6 +1,6 @@
+require 'segment/analytics/version'
 require 'segment/analytics/defaults'
 require 'segment/analytics/utils'
-require 'segment/analytics/version'
 require 'segment/analytics/client'
 require 'segment/analytics/worker'
 require 'segment/analytics/request'


### PR DESCRIPTION
```
balrog:web n$ be rspec
Bundler::GemRequireError: There was an error while trying to load the gem 'segment/analytics'.
Gem Load Error is: uninitialized constant Segment::Analytics::VERSION
Backtrace for gem load error is:
/Users/n/dev/rb/repos/web/vendor/bundle/ruby/2.4.0/gems/analytics-ruby-2.2.4/lib/segment/analytics/defaults.rb:12:in `<module:Request>'
/Users/n/dev/rb/repos/web/vendor/bundle/ruby/2.4.0/gems/analytics-ruby-2.2.4/lib/segment/analytics/defaults.rb:4:in `<module:Defaults>'
/Users/n/dev/rb/repos/web/vendor/bundle/ruby/2.4.0/gems/analytics-ruby-2.2.4/lib/segment/analytics/defaults.rb:3:in `<class:Analytics>'
/Users/n/dev/rb/repos/web/vendor/bundle/ruby/2.4.0/gems/analytics-ruby-2.2.4/lib/segment/analytics/defaults.rb:2:in `<module:Segment>'
/Users/n/dev/rb/repos/web/vendor/bundle/ruby/2.4.0/gems/analytics-ruby-2.2.4/lib/segment/analytics/defaults.rb:1:in `<top (required)>'
/Users/n/dev/rb/repos/web/vendor/bundle/ruby/2.4.0/gems/analytics-ruby-2.2.4/lib/segment/analytics.rb:1:in `<top (required)>'