### PR TITLE
Add missing 'forwardable' requirement

### DIFF
--- a/lib/segment/analytics/message_batch.rb
+++ b/lib/segment/analytics/message_batch.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require 'segment/analytics/logging'
 
 module Segment


### PR DESCRIPTION
This is unlikely to occur on most setups because another gem must've
'required' forwardable already. 

Similar to https://github.com/resque/resque/issues/1128. 