### PR TITLE
Revert "Reuse TCP connections"

### DIFF
--- a/lib/segment/analytics/request.rb
+++ b/lib/segment/analytics/request.rb
@@ -117,11 +117,6 @@ module Segment
 
           [200, '{}']
         else
-          # If `start` is not called, Ruby adds a 'Connection: close' header to
-          # all requests, preventing us from reusing a connection for multiple
-          # HTTP requests
-          @http.start unless @http.started?
-
           response = @http.request(request, payload)
           [response.code.to_i, response.body]
         end

--- a/lib/segment/analytics/worker.rb
+++ b/lib/segment/analytics/worker.rb
@@ -30,7 +30,6 @@ module Segment
         batch_size = options[:batch_size] || Defaults::MessageBatch::MAX_SIZE
         @batch = MessageBatch.new(batch_size)
         @lock = Mutex.new
-        @request = Request.new
       end
 
       # public: Continuously runs the loop to check for new events
@@ -45,7 +44,8 @@ module Segment
             end
           end
 
-          res = @request.post(@write_key, @batch)
+          res = Request.new.post @write_key, @batch
+
           @on_error.call(res.status, res.error) unless res.status == 200
 
           @lock.synchronize { @batch.clear }


### PR DESCRIPTION
Ref: https://github.com/segmentio/analytics-ruby/issues/167

This reverts commit 94179b8ae9b7686de462418b6a4f8c590d8902cf.