### PR TITLE
Move commander to development_dependencies, fixes #176

### DIFF
--- a/analytics-ruby.gemspec
+++ b/analytics-ruby.gemspec
@@ -16,20 +16,20 @@ Gem::Specification.new do |spec|
 
   # Ruby 1.8 requires json
   spec.add_dependency 'json', ['~> 1.7'] if RUBY_VERSION < "1.9"
-  spec.add_dependency 'commander', '~> 4.4'
 
+  # Used in the executable testing script
+  spec.add_development_dependency 'commander', '~> 4.4'
+
+  # Used in specs
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'tzinfo', '1.2.1'
   spec.add_development_dependency 'activesupport', '~> 4.1.11'
-
   if RUBY_VERSION >= '2.0' && RUBY_PLATFORM != 'java'
     spec.add_development_dependency 'oj', '~> 3.6.2'
   end
-
-  if RUBY_VERSION >= "2.1"
+  if RUBY_VERSION >= '2.1'
     spec.add_development_dependency 'rubocop', '~> 0.51.0'
   end
-
   spec.add_development_dependency 'codecov', '~> 0.1.4'
 end


### PR DESCRIPTION
Fixes #176. 

This PR changes the `commander` gem dependency from a runtime dependency to a development dependency. 

This gem is currently only used in the bin script used by https://github.com/segmentio/library-e2e-tester. Since the tester is invoked in https://github.com/segmentio/analytics-ruby/blob/4b0fa63e81704ddcc55ebcbac2c618ab6ee9b6f0/Makefile#L12, it should have access to all development dependencies (installed via bundler).