### PR TITLE
Client#track: respect context.library when set by client

### DIFF
--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -375,7 +375,7 @@ module Segment
       #
       # context - Hash of call context
       def add_context(context)
-        context[:library] = { :name => 'analytics-ruby', :version => Segment::Analytics::VERSION.to_s }
+        context[:library] ||= { :name => 'analytics-ruby', :version => Segment::Analytics::VERSION.to_s }
       end
 
       # private: Checks that the write_key is properly initialized

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -97,6 +97,20 @@ module Segment
           expect(properties[:date]).to eq('2013-01-01')
           expect(properties[:nottime]).to eq('x')
         end
+
+        it 'respects the context library property when set' do
+          library = 'custom library property'
+
+          client.track({
+            :event => 'testing with context.library set',
+            :user_id => 'test',
+            :context => { :library => library }
+          })
+
+          msg = queue.pop
+
+          expect(msg[:context][:library]).to eq(library)
+        end
       end
 
       describe '#identify' do


### PR DESCRIPTION
Zendesk Support Ticket ID: 171219

**Purpose**

Respect `context.library` property when set by client in order to populate the Amplitude Platform property.

**Context**

The `context.library` property is used to populate the 'official' [Amplitude Platform property](https://amplitude.zendesk.com/hc/en-us/articles/215562387-Appendix-Amplitude-User-Property-Definitions) for Segment server libraries.

The intention of this PR is to align the Segment Ruby library's behavior with respect to the `context.library` property with the [Node library's behavior](https://github.com/segmentio/analytics-node/blob/master/index.js#L171)- specifically to respect the value of `context.library` if it's set by the caller.