### PR TITLE
Remove #sleep calls in tests

### DIFF
--- a/spec/segment/analytics_spec.rb
+++ b/spec/segment/analytics_spec.rb
@@ -17,7 +17,7 @@ module Segment
         it 'does not error with the required options' do
           expect do
             analytics.track Queued::TRACK
-            sleep(1)
+            analytics.flush
           end.to_not raise_error
         end
       end
@@ -29,7 +29,7 @@ module Segment
 
         it 'does not error with the required options' do
           analytics.identify Queued::IDENTIFY
-          sleep(1)
+          analytics.flush
         end
       end
 
@@ -45,7 +45,7 @@ module Segment
         it 'does not error with the required options' do
           expect do
             analytics.alias ALIAS
-            sleep(1)
+            analytics.flush
           end.to_not raise_error
         end
       end
@@ -62,7 +62,7 @@ module Segment
         it 'does not error with the required options' do
           expect do
             analytics.group Queued::GROUP
-            sleep(1)
+            analytics.flush
           end.to_not raise_error
         end
       end
@@ -75,7 +75,7 @@ module Segment
         it 'does not error with the required options' do
           expect do
             analytics.page Queued::PAGE
-            sleep(1)
+            analytics.flush
           end.to_not raise_error
         end
       end
@@ -88,7 +88,7 @@ module Segment
         it 'does not error with the required options' do
           expect do
             analytics.screen Queued::SCREEN
-            sleep(1)
+            analytics.flush
           end.to_not raise_error
         end
       end


### PR DESCRIPTION
This shaves a couple of seconds off tests, and makes them more reliable by not relying on `#sleep` calls. 