### PR TITLE
Don't assume that all errors are ConnectionErrors

### DIFF
--- a/lib/segment/analytics/request.rb
+++ b/lib/segment/analytics/request.rb
@@ -53,7 +53,7 @@ module Segment
         if exception
           logger.error(exception.message)
           exception.backtrace.each { |line| logger.error(line) }
-          Response.new(-1, "Connection error: #{exception}")
+          Response.new(-1, exception.to_s)
         else
           last_response
         end

--- a/spec/segment/analytics/request_spec.rb
+++ b/spec/segment/analytics/request_spec.rb
@@ -232,7 +232,7 @@ module Segment
 
             it 'has a connection error' do
               error = subject.post(write_key, batch).error
-              expect(error).to match(/Connection error/)
+              expect(error).to match(/Malformed JSON/)
             end
 
             it_behaves_like('retried request', 200, 'Malformed JSON ---')


### PR DESCRIPTION
Fixes an issue mentioned in https://github.com/segmentio/analytics-ruby/issues/180. 

> The first part of the message ("Connection error") incorrectly led me to believe that the issue was in establishing a connection with Segment servers. This nudged my investigation towards HTTP-related issues and I eventually opened up a support ticket with Segment. We eventually realized the issue was a serialization error and were then able to correctly identify the problem and fix it. Had the error been labeled "Serialization error:" or something similar, finding the root of the bug would've taken much less time.