### PR TITLE
Allow anonymous_id in alias

### DIFF
--- a/lib/segment/analytics.rb
+++ b/lib/segment/analytics.rb
@@ -1,6 +1,7 @@
 require 'segment/analytics/version'
 require 'segment/analytics/defaults'
 require 'segment/analytics/utils'
+require 'segment/analytics/field_parser'
 require 'segment/analytics/client'
 require 'segment/analytics/worker'
 require 'segment/analytics/request'

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -42,6 +42,20 @@ module Segment
         end
       end
 
+      # @!macro common_attrs
+      #   @option attrs [String] :anonymous_id ID for a user when you don't know
+      #     who they are yet. (optional but you must provide either an
+      #     `anonymous_id` or `user_id`)
+      #   @option attrs [Hash] :context ({})
+      #   @option attrs [Hash] :integrations What integrations this event
+      #     goes to (optional)
+      #   @option attrs [String] :message_id ID that uniquely
+      #     identifies a message across the API. (optional)
+      #   @option attrs [Time] :timestamp When the event occurred (optional)
+      #   @option attrs [String] :user_id The ID for this user in your database
+      #     (optional but you must provide either an `anonymous_id` or `user_id`)
+      #   @option attrs [Hash] :options Options such as user traits (optional)
+
       # Tracks an event
       #
       # @see https://segment.com/docs/sources/server/ruby/#track
@@ -50,19 +64,7 @@ module Segment
       #
       # @option attrs [String] :event Event name
       # @option attrs [Hash] :properties Event properties (optional)
-      #
-      # @option attrs [String] :anonymous_id ID for a user when you don't know
-      #   who they are yet. (optional but you must provide either an
-      #   `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :context ({})
-      # @option attrs [Hash] :integrations What integrations this event
-      #   goes to (optional)
-      # @option attrs [String] :message_id ID that uniquely
-      #   identifies a message across the API. (optional)
-      # @option attrs [Time] :timestamp When the event occurred (optional)
-      # @option attrs [String] :user_id The ID for this user in your database
-      #   (optional but you must provide either an `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      # @macro common_attrs
       def track(attrs)
         symbolize_keys! attrs
         enqueue(FieldParser.parse_for_track(attrs))
@@ -75,19 +77,7 @@ module Segment
       # @param [Hash] attrs
       #
       # @option attrs [Hash] :traits User traits (optional)
-      #
-      # @option attrs [String] :anonymous_id ID for a user when you don't know
-      #   who they are yet. (optional but you must provide either an
-      #   `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :context ({})
-      # @option attrs [Hash] :integrations What integrations this event
-      #   goes to (optional)
-      # @option attrs [String] :message_id ID that uniquely
-      #   identifies a message across the API. (optional)
-      # @option attrs [Time] :timestamp When the event occurred (optional)
-      # @option attrs [String] :user_id The ID for this user in your database
-      #   (optional but you must provide either an `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      # @macro common_attrs
       def identify(attrs)
         symbolize_keys! attrs
         enqueue(FieldParser.parse_for_identify(attrs))
@@ -100,19 +90,7 @@ module Segment
       # @param [Hash] attrs
       #
       # @option attrs [String] :previous_id The ID to alias from
-      #
-      # @option attrs [String] :anonymous_id ID for a user when you don't know
-      #   who they are yet. (optional but you must provide either an
-      #   `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :context ({})
-      # @option attrs [Hash] :integrations What integrations this event
-      #   goes to (optional)
-      # @option attrs [String] :message_id ID that uniquely
-      #   identifies a message across the API. (optional)
-      # @option attrs [Time] :timestamp When the event occurred (optional)
-      # @option attrs [String] :user_id The ID for this user in your database
-      #   (optional but you must provide either an `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      # @macro common_attrs
       def alias(attrs)
         symbolize_keys! attrs
         enqueue(FieldParser.parse_for_alias(attrs))
@@ -126,19 +104,7 @@ module Segment
       #
       # @option attrs [String] :group_id The ID of the group
       # @option attrs [Hash] :traits User traits (optional)
-      #
-      # @option attrs [String] :anonymous_id ID for a user when you don't know
-      #   who they are yet. (optional but you must provide either an
-      #   `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :context ({})
-      # @option attrs [Hash] :integrations What integrations this event
-      #   goes to (optional)
-      # @option attrs [String] :message_id ID that uniquely
-      #   identifies a message across the API. (optional)
-      # @option attrs [Time] :timestamp When the event occurred (optional)
-      # @option attrs [String] :user_id The ID for this user in your database
-      #   (optional but you must provide either an `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      # @macro common_attrs
       def group(attrs)
         symbolize_keys! attrs
         enqueue(FieldParser.parse_for_group(attrs))
@@ -152,19 +118,7 @@ module Segment
       #
       # @option attrs [String] :name Name of the page
       # @option attrs [Hash] :properties Page properties (optional)
-      #
-      # @option attrs [String] :anonymous_id ID for a user when you don't know
-      #   who they are yet. (optional but you must provide either an
-      #   `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :context ({})
-      # @option attrs [Hash] :integrations What integrations this event
-      #   goes to (optional)
-      # @option attrs [String] :message_id ID that uniquely
-      #   identifies a message across the API. (optional)
-      # @option attrs [Time] :timestamp When the event occurred (optional)
-      # @option attrs [String] :user_id The ID for this user in your database
-      #   (optional but you must provide either an `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      # @macro common_attrs
       def page(attrs)
         symbolize_keys! attrs
         enqueue(FieldParser.parse_for_page(attrs))
@@ -177,19 +131,7 @@ module Segment
       # @option attrs [String] :name Name of the screen
       # @option attrs [Hash] :properties Screen properties (optional)
       # @option attrs [String] :category The screen category (optional)
-      #
-      # @option attrs [String] :anonymous_id ID for a user when you don't know
-      #   who they are yet. (optional but you must provide either an
-      #   `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :context ({})
-      # @option attrs [Hash] :integrations What integrations this event
-      #   goes to (optional)
-      # @option attrs [String] :message_id ID that uniquely
-      #   identifies a message across the API. (optional)
-      # @option attrs [Time] :timestamp When the event occurred (optional)
-      # @option attrs [String] :user_id The ID for this user in your database
-      #   (optional but you must provide either an `anonymous_id` or `user_id`)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      # @macro common_attrs
       def screen(attrs)
         symbolize_keys! attrs
         enqueue(FieldParser.parse_for_screen(attrs))

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -98,39 +98,24 @@ module Segment
       # @see https://segment.com/docs/sources/server/ruby/#alias
       #
       # @param [Hash] attrs
-      # @option attrs [Hash] :context ({})
-      # @option attrs [Hash] :integrations What integrations this must be
-      #   sent to (optional)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      #
       # @option attrs [String] :previous_id The ID to alias from
-      # @option attrs [Time] :timestamp When the alias occurred (optional)
-      # @option attrs [String] :user_id The ID to alias to
-      # @option attrs [String] :message_id ID that uniquely identifies a
-      #   message across the API. (optional)
+      #
+      # @option attrs [String] :anonymous_id ID for a user when you don't know
+      #   who they are yet. (optional but you must provide either an
+      #   `anonymous_id` or `user_id`)
+      # @option attrs [Hash] :context ({})
+      # @option attrs [Hash] :integrations What integrations this event
+      #   goes to (optional)
+      # @option attrs [String] :message_id ID that uniquely
+      #   identifies a message across the API. (optional)
+      # @option attrs [Time] :timestamp When the event occurred (optional)
+      # @option attrs [String] :user_id The ID for this user in your database
+      #   (optional but you must provide either an `anonymous_id` or `user_id`)
+      # @option attrs [Hash] :options Options such as user traits (optional)
       def alias(attrs)
         symbolize_keys! attrs
-
-        from = attrs[:previous_id]
-        to = attrs[:user_id]
-        timestamp = attrs[:timestamp] || Time.new
-        context = attrs[:context] || {}
-        message_id = attrs[:message_id].to_s if attrs[:message_id]
-
-        check_presence! from, 'previous_id'
-        check_presence! to, 'user_id'
-        check_timestamp! timestamp
-        add_context context
-
-        enqueue({
-          :previousId => from,
-          :userId => to,
-          :integrations => attrs[:integrations],
-          :context => context,
-          :options => attrs[:options],
-          :messageId => message_id,
-          :timestamp => datetime_in_iso8601(timestamp),
-          :type => 'alias'
-        })
+        enqueue(FieldParser.parse_for_alias(attrs))
       end
 
       # Associates a user identity with a group.

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -23,9 +23,8 @@ module Segment
         @queue = Queue.new
         @write_key = opts[:write_key]
         @max_queue_size = opts[:max_queue_size] || Defaults::Queue::MAX_SIZE
-        @options = opts
         @worker_mutex = Mutex.new
-        @worker = Worker.new(@queue, @write_key, @options)
+        @worker = Worker.new(@queue, @write_key, opts)
 
         check_write_key!
 

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -388,19 +388,6 @@ module Segment
         raise ArgumentError, 'Timestamp must be a Time' unless timestamp.is_a? Time
       end
 
-      def event(attrs)
-        symbolize_keys! attrs
-
-        {
-          :userId => user_id,
-          :name => name,
-          :properties => properties,
-          :context => context,
-          :timestamp => datetime_in_iso8601(timestamp),
-          :type => 'screen'
-        }
-      end
-
       def check_user_id!(attrs)
         unless attrs[:user_id] || attrs[:anonymous_id]
           raise ArgumentError, 'Must supply either user_id or anonymous_id'

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -149,49 +149,25 @@ module Segment
       # @see https://segment.com/docs/sources/server/ruby/#page
       #
       # @param [Hash] attrs
+      #
+      # @option attrs [String] :name Name of the page
+      # @option attrs [Hash] :properties Page properties (optional)
+      #
       # @option attrs [String] :anonymous_id ID for a user when you don't know
       #   who they are yet. (optional but you must provide either an
       #   `anonymous_id` or `user_id`)
-      # @option attrs [String] :category The page category (optional)
       # @option attrs [Hash] :context ({})
       # @option attrs [Hash] :integrations What integrations this event
       #   goes to (optional)
-      # @option attrs [String] :name Name of the page
+      # @option attrs [String] :message_id ID that uniquely
+      #   identifies a message across the API. (optional)
+      # @option attrs [Time] :timestamp When the event occurred (optional)
+      # @option attrs [String] :user_id The ID for this user in your database
+      #   (optional but you must provide either an `anonymous_id` or `user_id`)
       # @option attrs [Hash] :options Options such as user traits (optional)
-      # @option attrs [Hash] :properties Page properties (optional)
-      # @option attrs [Time] :timestamp When the pageview occurred (optional)
-      # @option attrs [String] :user_id The ID of the user viewing the page
-      # @option attrs [String] :message_id ID that uniquely identifies a
-      #   message across the API. (optional)
       def page(attrs)
         symbolize_keys! attrs
-        check_user_id! attrs
-
-        name = attrs[:name].to_s
-        properties = attrs[:properties] || {}
-        timestamp = attrs[:timestamp] || Time.new
-        context = attrs[:context] || {}
-        message_id = attrs[:message_id].to_s if attrs[:message_id]
-
-        raise ArgumentError, '.properties must be a hash' unless properties.is_a? Hash
-        isoify_dates! properties
-
-        check_timestamp! timestamp
-        add_context context
-
-        enqueue({
-          :userId => attrs[:user_id],
-          :anonymousId => attrs[:anonymous_id],
-          :name => name,
-          :category => attrs[:category],
-          :properties => properties,
-          :integrations => attrs[:integrations],
-          :options => attrs[:options],
-          :context => context,
-          :messageId => message_id,
-          :timestamp => datetime_in_iso8601(timestamp),
-          :type => 'page'
-        })
+        enqueue(FieldParser.parse_for_page(attrs))
       end
 
       # Records a screen view (for a mobile app)

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -73,46 +73,24 @@ module Segment
       # @see https://segment.com/docs/sources/server/ruby/#identify
       #
       # @param [Hash] attrs
+      #
+      # @option attrs [Hash] :traits User traits (optional)
+      #
       # @option attrs [String] :anonymous_id ID for a user when you don't know
       #   who they are yet. (optional but you must provide either an
       #   `anonymous_id` or `user_id`)
       # @option attrs [Hash] :context ({})
       # @option attrs [Hash] :integrations What integrations this event
       #   goes to (optional)
-      # @option attrs [Hash] :options Options such as user traits (optional)
+      # @option attrs [String] :message_id ID that uniquely
+      #   identifies a message across the API. (optional)
       # @option attrs [Time] :timestamp When the event occurred (optional)
-      # @option attrs [Hash] :traits User traits (optional)
       # @option attrs [String] :user_id The ID for this user in your database
       #   (optional but you must provide either an `anonymous_id` or `user_id`)
-      # @option attrs [String] :message_id ID that uniquely identifies a
-      #   message across the API. (optional)
+      # @option attrs [Hash] :options Options such as user traits (optional)
       def identify(attrs)
         symbolize_keys! attrs
-        check_user_id! attrs
-
-        traits = attrs[:traits] || {}
-        timestamp = attrs[:timestamp] || Time.new
-        context = attrs[:context] || {}
-        message_id = attrs[:message_id].to_s if attrs[:message_id]
-
-        check_timestamp! timestamp
-
-        raise ArgumentError, 'Must supply traits as a hash' unless traits.is_a? Hash
-        isoify_dates! traits
-
-        add_context context
-
-        enqueue({
-          :userId => attrs[:user_id],
-          :anonymousId => attrs[:anonymous_id],
-          :integrations => attrs[:integrations],
-          :context => context,
-          :traits => traits,
-          :options => attrs[:options],
-          :messageId => message_id,
-          :timestamp => datetime_in_iso8601(timestamp),
-          :type => 'identify'
-        })
+        enqueue(FieldParser.parse_for_identify(attrs))
       end
 
       # Aliases a user from one id to another

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -173,49 +173,26 @@ module Segment
       # Records a screen view (for a mobile app)
       #
       # @param [Hash] attrs
+      #
+      # @option attrs [String] :name Name of the screen
+      # @option attrs [Hash] :properties Screen properties (optional)
+      # @option attrs [String] :category The screen category (optional)
+      #
       # @option attrs [String] :anonymous_id ID for a user when you don't know
       #   who they are yet. (optional but you must provide either an
       #   `anonymous_id` or `user_id`)
-      # @option attrs [String] :category The screen category (optional)
       # @option attrs [Hash] :context ({})
       # @option attrs [Hash] :integrations What integrations this event
       #   goes to (optional)
-      # @option attrs [String] :name Name of the screen
+      # @option attrs [String] :message_id ID that uniquely
+      #   identifies a message across the API. (optional)
+      # @option attrs [Time] :timestamp When the event occurred (optional)
+      # @option attrs [String] :user_id The ID for this user in your database
+      #   (optional but you must provide either an `anonymous_id` or `user_id`)
       # @option attrs [Hash] :options Options such as user traits (optional)
-      # @option attrs [Hash] :properties Page properties (optional)
-      # @option attrs [Time] :timestamp When the pageview occurred (optional)
-      # @option attrs [String] :user_id The ID of the user viewing the screen
-      # @option attrs [String] :message_id ID that uniquely identifies a
-      #   message across the API. (optional)
       def screen(attrs)
         symbolize_keys! attrs
-        check_user_id! attrs
-
-        name = attrs[:name].to_s
-        properties = attrs[:properties] || {}
-        timestamp = attrs[:timestamp] || Time.new
-        context = attrs[:context] || {}
-        message_id = attrs[:message_id].to_s if attrs[:message_id]
-
-        raise ArgumentError, '.properties must be a hash' unless properties.is_a? Hash
-        isoify_dates! properties
-
-        check_timestamp! timestamp
-        add_context context
-
-        enqueue({
-          :userId => attrs[:user_id],
-          :anonymousId => attrs[:anonymous_id],
-          :name => name,
-          :properties => properties,
-          :category => attrs[:category],
-          :options => attrs[:options],
-          :integrations => attrs[:integrations],
-          :context => context,
-          :messageId => message_id,
-          :timestamp => timestamp.iso8601,
-          :type => 'screen'
-        })
+        enqueue(FieldParser.parse_for_screen(attrs))
       end
 
       # @return [Fixnum] number of messages in the queue

--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -224,27 +224,9 @@ module Segment
         end
       end
 
-      # private: Adds contextual information to the call
-      #
-      # context - Hash of call context
-      def add_context(context)
-        context[:library] = { :name => 'analytics-ruby', :version => Segment::Analytics::VERSION.to_s }
-      end
-
       # private: Checks that the write_key is properly initialized
       def check_write_key!
         raise ArgumentError, 'Write key must be initialized' if @write_key.nil?
-      end
-
-      # private: Checks the timstamp option to make sure it is a Time.
-      def check_timestamp!(timestamp)
-        raise ArgumentError, 'Timestamp must be a Time' unless timestamp.is_a? Time
-      end
-
-      def check_user_id!(attrs)
-        unless attrs[:user_id] || attrs[:anonymous_id]
-          raise ArgumentError, 'Must supply either user_id or anonymous_id'
-        end
       end
 
       def ensure_worker_running

--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -82,6 +82,28 @@ module Segment
           })
         end
 
+        # In addition to the common fields, page accepts:
+        #
+        # - "name"
+        # - "properties"
+        def parse_for_page(fields)
+          common = parse_common_fields(fields)
+
+          name = fields[:name]
+          properties = fields[:properties] || {}
+
+          check_presence!(name, 'name')
+          check_is_hash!(properties, 'properties')
+
+          isoify_dates! properties
+
+          common.merge({
+            :type => 'page',
+            :name => name.to_s,
+            :properties => properties
+          })
+        end
+
         private
 
         def parse_common_fields(fields)

--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -1,0 +1,85 @@
+module Segment
+  class Analytics
+    # Handles parsing fields according to the Segment Spec
+    #
+    # @see https://segment.com/docs/spec/
+    class FieldParser
+      class << self
+        include Segment::Analytics::Utils
+
+        # In addition to the common fields, track accepts:
+        #
+        # - "event"
+        # - "properties"
+        def parse_for_track(fields)
+          common = parse_common_fields(fields)
+
+          event = fields[:event]
+          properties = fields[:properties] || {}
+
+          check_presence!(event, 'event')
+          check_is_hash!(properties, 'properties')
+
+          isoify_dates! properties
+
+          common.merge({
+            :type => 'track',
+            :event => event.to_s,
+            :properties => properties
+          })
+        end
+
+        private
+
+        def parse_common_fields(fields)
+          timestamp = fields[:timestamp] || Time.new
+          message_id = fields[:message_id].to_s if fields[:message_id]
+          context = fields[:context] || {}
+
+          check_user_id! fields
+          check_timestamp! timestamp
+
+          add_context! context
+
+          {
+            :anonymousId => fields[:anonymous_id],
+            :context => context,
+            :integrations => fields[:integrations],
+            :messageId => message_id,
+            :timestamp => datetime_in_iso8601(timestamp),
+            :userId => fields[:user_id],
+            :options => fields[:options] # Not in spec, retained for backward compatibility
+          }
+        end
+
+        def check_user_id!(fields)
+          unless fields[:user_id] || fields[:anonymous_id]
+            raise ArgumentError, 'Must supply either user_id or anonymous_id'
+          end
+        end
+
+        def check_timestamp!(timestamp)
+          raise ArgumentError, 'Timestamp must be a Time' unless timestamp.is_a? Time
+        end
+
+        def add_context!(context)
+          context[:library] = { :name => 'analytics-ruby', :version => Segment::Analytics::VERSION.to_s }
+        end
+
+        # private: Ensures that a string is non-empty
+        #
+        # obj    - String|Number that must be non-blank
+        # name   - Name of the validated value
+        def check_presence!(obj, name)
+          if obj.nil? || (obj.is_a?(String) && obj.empty?)
+            raise ArgumentError, "#{name} must be given"
+          end
+        end
+
+        def check_is_hash!(obj, name)
+          raise ArgumentError, "#{name} must be a Hash" unless obj.is_a? Hash
+        end
+      end
+    end
+  end
+end

--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -104,6 +104,31 @@ module Segment
           })
         end
 
+        # In addition to the common fields, screen accepts:
+        #
+        # - "name"
+        # - "properties"
+        # - "category" (Not in spec, retained for backward compatibility"
+        def parse_for_screen(fields)
+          common = parse_common_fields(fields)
+
+          name = fields[:name]
+          properties = fields[:properties] || {}
+          category = fields[:category]
+
+          check_presence!(name, 'name')
+          check_is_hash!(properties, 'properties')
+
+          isoify_dates! properties
+
+          common.merge({
+            :type => 'screen',
+            :name => name,
+            :properties => properties,
+            :category => category
+          })
+        end
+
         private
 
         def parse_common_fields(fields)

--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -45,6 +45,21 @@ module Segment
           })
         end
 
+        # In addition to the common fields, alias accepts:
+        #
+        # - "previous_id"
+        def parse_for_alias(fields)
+          common = parse_common_fields(fields)
+
+          previous_id = fields[:previous_id]
+          check_presence!(previous_id, 'previous_id')
+
+          common.merge({
+            :type => 'alias',
+            :previousId => previous_id
+          })
+        end
+
         private
 
         def parse_common_fields(fields)

--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -29,6 +29,22 @@ module Segment
           })
         end
 
+        # In addition to the common fields, identify accepts:
+        #
+        # - "traits"
+        def parse_for_identify(fields)
+          common = parse_common_fields(fields)
+
+          traits = fields[:traits] || {}
+          check_is_hash!(traits, 'traits')
+          isoify_dates! traits
+
+          common.merge({
+            :type => 'identify',
+            :traits => traits
+          })
+        end
+
         private
 
         def parse_common_fields(fields)

--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -60,6 +60,28 @@ module Segment
           })
         end
 
+        # In addition to the common fields, group accepts:
+        #
+        # - "group_id"
+        # - "traits"
+        def parse_for_group(fields)
+          common = parse_common_fields(fields)
+
+          group_id = fields[:group_id]
+          traits = fields[:traits] || {}
+
+          check_presence!(group_id, 'group_id')
+          check_is_hash!(traits, 'traits')
+
+          isoify_dates! traits
+
+          common.merge({
+            :type => 'group',
+            :groupId => group_id,
+            :traits => traits
+          })
+        end
+
         private
 
         def parse_common_fields(fields)

--- a/spec/segment/analytics_spec.rb
+++ b/spec/segment/analytics_spec.rb
@@ -10,8 +10,10 @@ module Segment
           expect { analytics.track(:user_id => 'user') }.to raise_error(ArgumentError)
         end
 
-        it 'errors without a user_id' do
-          expect { analytics.track(:event => 'Event') }.to raise_error(ArgumentError)
+        it 'errors without user_id or anonymous_id' do
+          expect { analytics.track :event => 'event' }.to raise_error(ArgumentError)
+          expect { analytics.track :event => 'event', user_id: '1234' }.to_not raise_error(ArgumentError)
+          expect { analytics.track :event => 'event', anonymous_id: '2345' }.to_not raise_error(ArgumentError)
         end
 
         it 'does not error with the required options' do
@@ -23,8 +25,10 @@ module Segment
       end
 
       describe '#identify' do
-        it 'errors without a user_id' do
+        it 'errors without user_id or anonymous_id' do
           expect { analytics.identify :traits => {} }.to raise_error(ArgumentError)
+          expect { analytics.identify :traits => {}, user_id: '1234' }.to_not raise_error(ArgumentError)
+          expect { analytics.identify :traits => {}, anonymous_id: '2345' }.to_not raise_error(ArgumentError)
         end
 
         it 'does not error with the required options' do
@@ -34,12 +38,14 @@ module Segment
       end
 
       describe '#alias' do
-        it 'errors without from' do
+        it 'errors without previous_id' do
           expect { analytics.alias :user_id => 1234 }.to raise_error(ArgumentError)
         end
 
-        it 'errors without to' do
-          expect { analytics.alias :previous_id => 1234 }.to raise_error(ArgumentError)
+        it 'errors without user_id or anonymous_id' do
+          expect { analytics.alias :previous_id => 'foo' }.to raise_error(ArgumentError)
+          expect { analytics.alias :previous_id => 'foo', user_id: '1234' }.to_not raise_error(ArgumentError)
+          expect { analytics.alias :previous_id => 'foo', anonymous_id: '2345' }.to_not raise_error(ArgumentError)
         end
 
         it 'does not error with the required options' do
@@ -57,6 +63,8 @@ module Segment
 
         it 'errors without user_id or anonymous_id' do
           expect { analytics.group :group_id => 'foo' }.to raise_error(ArgumentError)
+          expect { analytics.group :group_id => 'foo', user_id: '1234' }.to_not raise_error(ArgumentError)
+          expect { analytics.group :group_id => 'foo', anonymous_id: '2345' }.to_not raise_error(ArgumentError)
         end
 
         it 'does not error with the required options' do
@@ -70,6 +78,8 @@ module Segment
       describe '#page' do
         it 'errors without user_id or anonymous_id' do
           expect { analytics.page :name => 'foo' }.to raise_error(ArgumentError)
+          expect { analytics.page :name => 'foo', user_id: '1234' }.to_not raise_error(ArgumentError)
+          expect { analytics.page :name => 'foo', anonymous_id: '2345' }.to_not raise_error(ArgumentError)
         end
 
         it 'does not error with the required options' do
@@ -83,6 +93,8 @@ module Segment
       describe '#screen' do
         it 'errors without user_id or anonymous_id' do
           expect { analytics.screen :name => 'foo' }.to raise_error(ArgumentError)
+          expect { analytics.screen :name => 'foo', user_id: '1234' }.to_not raise_error(ArgumentError)
+          expect { analytics.screen :name => 'foo', anonymous_id: '2345' }.to_not raise_error(ArgumentError)
         end
 
         it 'does not error with the required options' do


### PR DESCRIPTION
Fixes https://github.com/segmentio/analytics-ruby/issues/181. 

This PR refactors the handling of common fields, extracts a `FieldParser` that adheres to the Segment spec. 

This will result in the following behaviour changes: 

- `alias` will now accept `anonymous_id`
- `group` will now accept `anonymous_id`
- `page` will now validate that `name` is non-empty

As I refactored this to adhere to the [Segment spec](https://segment.com/docs/spec/screen/), I found a couple of deviations from the spec:

- `options` is accepted in every call, but not mentioned in the spec
- `screen` takes a `category` parameter, which is not mentioned in the spec

I've retained these for backwards compatibility. 