### PR TITLE
Client#track: respect context.library when set by client

### DIFF
--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -375,7 +375,7 @@ module Segment
       #
       # context - Hash of call context
       def add_context(context)
-        context[:library] = { :name => 'analytics-ruby', :version => Segment::Analytics::VERSION.to_s }
+        context[:library] ||= { :name => 'analytics-ruby', :version => Segment::Analytics::VERSION.to_s }
       end
 
       # private: Checks that the write_key is properly initialized

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -102,6 +102,20 @@ module Segment
 
           expect(properties[:nottime]).to eq('x')
         end
+
+        it 'respects the context library property when set' do
+          library = 'custom library property'
+
+          client.track({
+            :event => 'testing with context.library set',
+            :user_id => 'test',
+            :context => { :library => library }
+          })
+
+          msg = queue.pop
+
+          expect(msg[:context][:library]).to eq(library)
+        end
       end
 
       describe '#identify' do


### PR DESCRIPTION
#183, rebased on master. 