### PR TITLE
Make :name optional in #page

### DIFF
--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -89,10 +89,9 @@ module Segment
         def parse_for_page(fields)
           common = parse_common_fields(fields)
 
-          name = fields[:name]
+          name = fields[:name] || ''
           properties = fields[:properties] || {}
 
-          check_presence!(name, 'name')
           check_is_hash!(properties, 'properties')
 
           isoify_dates! properties

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -224,10 +224,12 @@ module Segment
           expect { client.page Queued::PAGE }.to_not raise_error
         end
 
-        it 'does not error with the required options as strings' do
-          expect do
-            client.page Utils.stringify_keys(Queued::PAGE)
-          end.to_not raise_error
+        it 'accepts name' do
+          client.page :name => 'foo', :user_id => 1234
+
+          message = queue.pop
+          expect(message[:userId]).to eq(1234)
+          expect(message[:name]).to eq('foo')
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,9 +39,7 @@ module Segment
 
     GROUP = {}
 
-    PAGE = {
-      :name => 'home'
-    }
+    PAGE = {}
 
     SCREEN = {
       :name => 'main'


### PR DESCRIPTION
Fixes #192.

This bug was introduced in #188, I misread the Segment spec. 