### PR TITLE
Update history to reflect 2.2.7 release

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,4 @@
-2.2.7.pre / 2019-05-09
+2.2.7 / 2019-05-09
 ==================
 
   * [Fix](https://github.com/segmentio/analytics-ruby/pull/188): Allow `anonymous_id`


### PR DESCRIPTION
Due to a bug in the release script, we accidentally released 2.2.7
directly instead of going through a pre-release.