### PR TITLE
Remove 1.9.3 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 
 rvm:
   - jruby-19mode
-  - 1.9.3
   - 2.0.0
   - 2.1.10
   - 2.2.9


### PR DESCRIPTION
Travis doesn't support 1.9.3 anymore, as it looks for RVM binaries
and they aren't available for 14.04.

Ref: https://rvm.io/binaries/ubuntu/16.04/x86_64/