### PR TITLE
Explicitly initialize @worker_thread

### DIFF
--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -25,6 +25,7 @@ module Segment
         @max_queue_size = opts[:max_queue_size] || Defaults::Queue::MAX_SIZE
         @worker_mutex = Mutex.new
         @worker = Worker.new(@queue, @write_key, opts)
+        @worker_thread = nil
 
         check_write_key!
 


### PR DESCRIPTION
Without this, some modern rubies will emit this warning:

/usr/local/bundle/gems/analytics-ruby-2.2.7/lib/segment/analytics/client.rb:31: warning: instance variable @worker_thread not initialized