### PR TITLE
Set minimum ruby version to 2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  # Rubocop doesn't support 1.9, so we'll use the minimum available
+  # Rubocop doesn't support 2.0, so we'll use the minimum available
   TargetRubyVersion: 2.1
 
 Layout/IndentHash:
@@ -84,7 +84,3 @@ Style/ParallelAssignment:
 
 Style/PreferredHashMethods:
   EnforcedStyle: verbose
-
-# Ruby 1.9 doesn't support percent-styled symbol arrays
-Style/SymbolArray:
-  EnforcedStyle: brackets

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - jruby-19mode
   - 2.0.0
   - 2.1.10
   - 2.2.9

--- a/analytics-ruby.gemspec
+++ b/analytics-ruby.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |spec|
   spec.email = 'friends@segment.io'
   spec.homepage = 'https://github.com/segmentio/analytics-ruby'
   spec.license = 'MIT'
-
-  # Ruby 1.8 requires json
-  spec.add_dependency 'json', ['~> 1.7'] if RUBY_VERSION < "1.9"
+  spec.required_ruby_version = '>= 2.0'
 
   # Used in the executable testing script
   spec.add_development_dependency 'commander', '~> 4.4'

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -281,7 +281,7 @@ module Segment
         let(:data) { { :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :message_id => 5, :event => 'coco barked', :name => 'coco' } }
 
         it 'does not convert ids given as fixnums to strings' do
-          [:track, :screen, :page, :identify].each do |s|
+          %i[track screen page identify].each do |s|
             client.send(s, data)
             message = queue.pop(true)
 
@@ -293,7 +293,7 @@ module Segment
         it 'returns false if queue is full' do
           client.instance_variable_set(:@max_queue_size, 1)
 
-          [:track, :screen, :page, :group, :identify, :alias].each do |s|
+          %i[track screen page group identify alias].each do |s|
             expect(client.send(s, data)).to eq(true)
             expect(client.send(s, data)).to eq(false) # Queue is full
             queue.pop(true)
@@ -301,7 +301,7 @@ module Segment
         end
 
         it 'converts message id to string' do
-          [:track, :screen, :page, :group, :identify, :alias].each do |s|
+          %i[track screen page group identify alias].each do |s|
             client.send(s, data)
             message = queue.pop(true)
 
@@ -330,7 +330,7 @@ module Segment
         end
 
         it 'sends integrations' do
-          [:track, :screen, :page, :group, :identify, :alias].each do |s|
+          %i[track screen page group identify alias].each do |s|
             client.send s, :integrations => { :All => true, :Salesforce => false }, :user_id => 1, :group_id => 2, :previous_id => 3, :anonymous_id => 4, :event => 'coco barked', :name => 'coco'
             message = queue.pop(true)
             expect(message[:integrations][:All]).to eq(true)


### PR DESCRIPTION
Includes minor code/docs cleanup in areas that were 1.9-specific. 

Ref: [Ruby 2.0 EOL'ed 3 years ago](https://endoflife.date/ruby). 