### PR TITLE
Avoid network calls in tests

### DIFF
--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -250,7 +250,12 @@ module Segment
       end
 
       describe '#flush' do
-        let(:client_with_worker) { Client.new(:write_key => WRITE_KEY) }
+        let(:client_with_worker) {
+          Client.new(:write_key => WRITE_KEY).tap { |client|
+            queue = client.instance_variable_get(:@queue)
+            client.instance_variable_set(:@worker, DummyWorker.new(queue))
+          }
+        }
 
         it 'waits for the queue to finish on a flush' do
           client_with_worker.identify Queued::IDENTIFY

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,6 +88,21 @@ class NoopWorker
   end
 end
 
+# A worker that consumes all jobs
+class DummyWorker
+  def initialize(queue)
+    @queue = queue
+  end
+
+  def run
+    @queue.pop until @queue.empty?
+  end
+
+  def is_requesting?
+    false
+  end
+end
+
 # A backoff policy that returns a fixed list of values
 class FakeBackoffPolicy
   def initialize(interval_values)


### PR DESCRIPTION
A few unit tests were sending actual HTTP requests to Segment. Added mocks/stubs at the right places to prevent this from happening.

Tests used to take ~20 seconds to run on my machine, they now take ~1.5 seconds.