### PR TITLE
Fix stubbed request message

### DIFF
--- a/lib/segment/analytics/request.rb
+++ b/lib/segment/analytics/request.rb
@@ -113,7 +113,7 @@ module Segment
 
         if self.class.stub
           logger.debug "stubbed request to #{@path}: " \
-            "write key = #{write_key}, batch = JSON.generate(#{batch})"
+            "write key = #{write_key}, batch = #{JSON.generate(batch)}"
 
           [200, '{}']
         else


### PR DESCRIPTION
The client logs invalid data in the stubbed mode.

Example message: `[analytics-ruby] stubbed request to /v1/import: write key = test-key, batch = JSON.generate(#<Segment::Analytics::MessageBatch:0x00007fe40420b490>)`

Expected: actual hash instead of `<Segment::Analytics::MessageBatch:0x00007fe40420b490>`.
