### PR TITLE
Add test option and queue for easier testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,78 @@ Documentation is available at [segment.com/docs/sources/server/ruby](https://seg
 
 ## Testing
 
-You can use the `stub` option to Segment::Analytics.new to cause all requests to be stubbed, making it easier to test with this library.
+You can use the `stub: true` option to Segment::Analytics.new to cause all requests to be stubbed, making it easier to test with this library.
+
+### Test Queue
+
+You can use the `test: true` option to Segment::Analytics.new to cause all requests to be saved to a test queue until manually reset. All events will process as specified by the configuration, and they will also be stored in a separate queue for inspection during testing.
+
+A test queue can be used as follows:
+
+```ruby
+client = Segment::Analytics.new(test: true)
+
+client.test_queue # => #<Segment::Analytics::TestQueue:0x00007f88d454e9a8 @messages={}>
+
+client.track(user_id: "foo", event: "bar")
+
+client.test_queue.all
+# [
+#     {
+#            :context => {
+#             :library => {
+#                    :name => "analytics-ruby",
+#                 :version => "2.2.8.pre"
+#             }
+#         },
+#          :messageId => "e9754cc0-1c5e-47e4-832a-203589d279e4",
+#          :timestamp => "2021-02-19T13:32:39.547+01:00",
+#             :userId => "foo",
+#               :type => "track",
+#              :event => "bar",
+#         :properties => {}
+#     }
+# ]
+
+client.test_queue.track
+# [
+#     {
+#            :context => {
+#             :library => {
+#                    :name => "analytics-ruby",
+#                 :version => "2.2.8.pre"
+#             }
+#         },
+#          :messageId => "e9754cc0-1c5e-47e4-832a-203589d279e4",
+#          :timestamp => "2021-02-19T13:32:39.547+01:00",
+#             :userId => "foo",
+#               :type => "track",
+#              :event => "bar",
+#         :properties => {}
+#     }
+# ]
+
+# Other available methods
+client.test_queue.alias # => []
+client.test_queue.group # => []
+client.test_queue.identify # => []
+client.test_queue.page # => []
+client.test_queue.screen # => []
+
+client.reset!
+
+client.test_queue.all # => []
+```
+
+Note: It is recommended to call `reset!` before each test to ensure your test queue is empty. For example, in rspec you may have the following:
+
+```ruby
+RSpec.configure do |config|
+  config.before do
+    Analytics.test_queue.reset!
+  end
+end
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ client = Segment::Analytics.new(test: true)
 
 client.test_queue # => #<Segment::Analytics::TestQueue:0x00007f88d454e9a8 @messages={}>
 
-client.track(user_id: "foo", event: "bar")
+client.track(user_id: 'foo', event: 'bar')
 
 client.test_queue.all
 # [

--- a/lib/segment/analytics.rb
+++ b/lib/segment/analytics.rb
@@ -7,6 +7,7 @@ require 'segment/analytics/worker'
 require 'segment/analytics/transport'
 require 'segment/analytics/response'
 require 'segment/analytics/logging'
+require 'segment/analytics/test_queue'
 
 module Segment
   class Analytics

--- a/lib/segment/analytics/test_queue.rb
+++ b/lib/segment/analytics/test_queue.rb
@@ -1,0 +1,56 @@
+module Segment
+  class Analytics
+    class TestQueue
+      attr_reader :messages
+
+      def initialize
+        reset!
+      end
+
+      def [](key)
+        all[key]
+      end
+
+      def count
+        all.count
+      end
+
+      def <<(message)
+        all << message
+        send(message[:type]) << message
+      end
+
+      def alias
+        messages[:alias] ||= []
+      end
+
+      def all
+        messages[:all] ||= []
+      end
+
+      def group
+        messages[:group] ||= []
+      end
+
+      def identify
+        messages[:identify] ||= []
+      end
+
+      def page
+        messages[:page] ||= []
+      end
+
+      def screen
+        messages[:screen] ||= []
+      end
+
+      def track
+        messages[:track] ||= []
+      end
+
+      def reset!
+        @messages = {}
+      end
+    end
+  end
+end

--- a/spec/segment/analytics/test_queue_spec.rb
+++ b/spec/segment/analytics/test_queue_spec.rb
@@ -15,7 +15,7 @@ module Segment
         let(:message) do
           {
             type: type,
-            foo: "bar"
+            foo: 'bar'
           }
         end
 
@@ -140,21 +140,21 @@ module Segment
       describe '#count' do
         let(:message) do
           {
-            type: "alias",
-            foo: "bar"
+            type: 'alias',
+            foo: 'bar'
           }
         end
 
-        it "returns 0" do
+        it 'returns 0' do
           expect(test_queue.count).to eq(0)
         end
 
-        it "returns 1" do
+        it 'returns 1' do
           test_queue << message
           expect(test_queue.count).to eq(1)
         end
 
-        it "returns 2" do
+        it 'returns 2' do
           test_queue << message
           test_queue << message
           expect(test_queue.count).to eq(2)
@@ -164,29 +164,29 @@ module Segment
       describe '#[]' do
         let(:message1) do
           {
-            type: "alias",
-            foo: "bar"
+            type: 'alias',
+            foo: 'bar'
           }
         end
 
         let(:message2) do
           {
-            type: "identify",
-            foo: "baz"
+            type: 'identify',
+            foo: 'baz'
           }
         end
 
-        it "returns message1" do
+        it 'returns message1' do
           test_queue << message1
           expect(test_queue[0]).to eq(message1)
         end
 
-        it "returns message2" do
+        it 'returns message2' do
           test_queue << message2
           expect(test_queue[0]).to eq(message2)
         end
 
-        it "returns message2" do
+        it 'returns message2' do
           test_queue << message1
           test_queue << message2
           expect(test_queue[1]).to eq(message2)
@@ -196,12 +196,12 @@ module Segment
       describe '#reset!' do
         let(:message) do
           {
-            type: "alias",
-            foo: "bar"
+            type: 'alias',
+            foo: 'bar'
           }
         end
 
-        it "returns message" do
+        it 'returns message' do
           test_queue << message
           expect(test_queue.count).to eq(1)
           test_queue.reset!

--- a/spec/segment/analytics/test_queue_spec.rb
+++ b/spec/segment/analytics/test_queue_spec.rb
@@ -1,0 +1,213 @@
+require 'spec_helper'
+
+module Segment
+  class Analytics
+    describe TestQueue do
+      let(:test_queue) { described_class.new }
+
+      describe '#initialize' do
+        it 'starts empty' do
+          expect(test_queue.messages).to eq({})
+        end
+      end
+
+      describe '#<<' do
+        let(:message) do
+          {
+            type: type,
+            foo: "bar"
+          }
+        end
+
+        let(:expected_messages) do
+          {
+            type.to_sym => [message],
+            all: [message]
+          }
+        end
+
+        context 'when unsupported type' do
+          let(:type) { :foo }
+
+          it 'raises error' do
+            expect { test_queue << message }.to raise_error(NoMethodError)
+          end
+        end
+
+        context 'when supported type' do
+          before do
+            test_queue << message
+          end
+
+          context 'when type is alias' do
+            let(:type) { :alias }
+
+            it 'adds messages' do
+              expect(test_queue.messages).to eq(expected_messages)
+            end
+
+            it 'adds type to all' do
+              expect(test_queue.all).to eq([message])
+            end
+
+            it 'adds type to alias' do
+              expect(test_queue.alias).to eq([message])
+            end
+          end
+
+          context 'when type is group' do
+            let(:type) { :group }
+
+            it 'adds messages' do
+              expect(test_queue.messages).to eq(expected_messages)
+            end
+
+            it 'adds type to all' do
+              expect(test_queue.all).to eq([message])
+            end
+
+            it 'adds type to group' do
+              expect(test_queue.group).to eq([message])
+            end
+          end
+
+          context 'when type is identify' do
+            let(:type) { :identify }
+
+            it 'adds messages' do
+              expect(test_queue.messages).to eq(expected_messages)
+            end
+
+            it 'adds type to all' do
+              expect(test_queue.all).to eq([message])
+            end
+
+            it 'adds type to identify' do
+              expect(test_queue.identify).to eq([message])
+            end
+          end
+
+          context 'when type is page' do
+            let(:type) { :page }
+
+            it 'adds messages' do
+              expect(test_queue.messages).to eq(expected_messages)
+            end
+
+            it 'adds type to all' do
+              expect(test_queue.all).to eq([message])
+            end
+
+            it 'adds type to page' do
+              expect(test_queue.page).to eq([message])
+            end
+          end
+
+          context 'when type is screen' do
+            let(:type) { :screen }
+
+            it 'adds messages' do
+              expect(test_queue.messages).to eq(expected_messages)
+            end
+
+            it 'adds type to all' do
+              expect(test_queue.all).to eq([message])
+            end
+
+            it 'adds type to screen' do
+              expect(test_queue.screen).to eq([message])
+            end
+          end
+
+          context 'when type is track' do
+            let(:type) { :track }
+
+            it 'adds messages' do
+              expect(test_queue.messages).to eq(expected_messages)
+            end
+
+            it 'adds type to all' do
+              expect(test_queue.all).to eq([message])
+            end
+
+            it 'adds type to track' do
+              expect(test_queue.track).to eq([message])
+            end
+          end
+        end
+      end
+
+      describe '#count' do
+        let(:message) do
+          {
+            type: "alias",
+            foo: "bar"
+          }
+        end
+
+        it "returns 0" do
+          expect(test_queue.count).to eq(0)
+        end
+
+        it "returns 1" do
+          test_queue << message
+          expect(test_queue.count).to eq(1)
+        end
+
+        it "returns 2" do
+          test_queue << message
+          test_queue << message
+          expect(test_queue.count).to eq(2)
+        end
+      end
+
+      describe '#[]' do
+        let(:message1) do
+          {
+            type: "alias",
+            foo: "bar"
+          }
+        end
+
+        let(:message2) do
+          {
+            type: "identify",
+            foo: "baz"
+          }
+        end
+
+        it "returns message1" do
+          test_queue << message1
+          expect(test_queue[0]).to eq(message1)
+        end
+
+        it "returns message2" do
+          test_queue << message2
+          expect(test_queue[0]).to eq(message2)
+        end
+
+        it "returns message2" do
+          test_queue << message1
+          test_queue << message2
+          expect(test_queue[1]).to eq(message2)
+        end
+      end
+
+      describe '#reset!' do
+        let(:message) do
+          {
+            type: "alias",
+            foo: "bar"
+          }
+        end
+
+        it "returns message" do
+          test_queue << message
+          expect(test_queue.count).to eq(1)
+          test_queue.reset!
+          expect(test_queue.messages).to eq({})
+        end
+      end
+    end
+  end
+end

--- a/spec/segment/analytics_spec.rb
+++ b/spec/segment/analytics_spec.rb
@@ -127,6 +127,33 @@ module Segment
           end
         end
       end
+
+      describe '#test_queue' do
+        context 'when not in mode' do
+          let(:analytics) { Segment::Analytics.new :write_key => WRITE_KEY, :stub => true, :test => true }
+
+          it 'returns TestQueue' do
+            expect(analytics.test_queue).to be_a(TestQueue)
+          end
+
+          it 'returns event' do
+            analytics.track Queued::TRACK
+            expect(analytics.test_queue[0]).to include(Requested::TRACK)
+            expect(analytics.test_queue.track[0]).to include(Requested::TRACK)
+          end
+        end
+
+        context 'when not in test mode' do
+          let(:analytics) { Segment::Analytics.new :write_key => WRITE_KEY, :stub => true, :test => false }
+
+          it 'errors when not in test mode' do
+            expect(analytics.instance_variable_get(:@test)).to be_falsey
+            expect { analytics.test_queue }.to raise_error(
+              RuntimeError, 'Test queue only available when setting :test to true.'
+            )
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, we need to manually stub and override various functions within the gem to make it possible to test in rspec. This PR adds that functionality as an option to the gem itself. Perhaps also helpful, but not included here, would be some spec helpers for analytics (which we also have developed ourselves). Appreciate any feedback!