### PR TITLE
enable-overriding-transport-options Pass options when initializing Transport

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+2.3.2 / 2020-04-28
+==================
+
+* Enable overriding options in Transport (<https://github.com/segmentio/analytics-ruby/pull/222>)
+
 2.3.1 / 2020-04-13
 ==================
 

--- a/lib/segment/analytics/version.rb
+++ b/lib/segment/analytics/version.rb
@@ -1,5 +1,5 @@
 module Segment
   class Analytics
-    VERSION = '2.3.1'
+    VERSION = '2.3.2'
   end
 end

--- a/lib/segment/analytics/worker.rb
+++ b/lib/segment/analytics/worker.rb
@@ -29,7 +29,7 @@ module Segment
         batch_size = options[:batch_size] || Defaults::MessageBatch::MAX_SIZE
         @batch = MessageBatch.new(batch_size)
         @lock = Mutex.new
-        @transport = Transport.new
+        @transport = Transport.new(options)
       end
 
       # public: Continuously runs the loop to check for new events


### PR DESCRIPTION
This change will allow users to override the default options so the library can be more flexible 