### PR TITLE
Not enqueuing test action in real queue

### DIFF
--- a/lib/segment/analytics/client.rb
+++ b/lib/segment/analytics/client.rb
@@ -161,7 +161,10 @@ module Segment
         # add our request id for tracing purposes
         action[:messageId] ||= uid
 
-        test_queue << action if @test
+        if @test
+          test_queue << action
+          return true
+        end
 
         if @queue.length < @max_queue_size
           @queue << action
@@ -170,9 +173,7 @@ module Segment
           true
         else
           logger.warn(
-            'Queue is full, dropping events. The :max_queue_size ' \
-            'configuration parameter can be increased to prevent this from ' \
-            'happening.'
+            'Queue is full, dropping events. The :max_queue_size configuration parameter can be increased to prevent this from happening.'
           )
           false
         end

--- a/spec/segment/analytics/client_spec.rb
+++ b/spec/segment/analytics/client_spec.rb
@@ -342,6 +342,21 @@ module Segment
             expect(message[:integrations][:Salesforce]).to eq(false)
           end
         end
+
+        it 'does not enqueue the action in test mode' do
+          client.instance_variable_set(:@test, true)
+          client.test_queue
+          test_queue = client.instance_variable_get(:@test_queue)
+
+          %i[track screen page group identify alias].each do |s|
+            old_test_queue_size = test_queue.count
+            queue_size = queue.length
+            client.send(s, data)
+
+            expect(queue.length).to eq(queue_size) # The "real" queue size should not change in test mode
+            expect(test_queue.count).to_not eq(old_test_queue_size) # The "test" queue size should change in test mode
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
By using Segment in our application, we realized that the test events are also sent to the production source (therefore test persons count as MTU).
So I made a quick change to fix that and added a test to ensure that the "real" queue does not change.

Please, let me know what you think about it :) 