### PR TITLE
Fix for empty user_id or anonymous_id not throwing errors

### DIFF
--- a/lib/segment/analytics/field_parser.rb
+++ b/lib/segment/analytics/field_parser.rb
@@ -160,9 +160,10 @@ module Segment
         end
 
         def check_user_id!(fields)
-          unless fields[:user_id] || fields[:anonymous_id]
-            raise ArgumentError, 'Must supply either user_id or anonymous_id'
-          end
+          return unless blank?(fields[:user_id])
+          return unless blank?(fields[:anonymous_id])
+
+          raise ArgumentError, 'Must supply either user_id or anonymous_id'
         end
 
         def check_timestamp!(timestamp)
@@ -178,9 +179,13 @@ module Segment
         # obj    - String|Number that must be non-blank
         # name   - Name of the validated value
         def check_presence!(obj, name)
-          if obj.nil? || (obj.is_a?(String) && obj.empty?)
+          if blank?(obj)
             raise ArgumentError, "#{name} must be given"
           end
+        end
+
+        def blank?(obj)
+          obj.nil? || (obj.is_a?(String) && obj.empty?)
         end
 
         def check_is_hash!(obj, name)

--- a/spec/segment/analytics_spec.rb
+++ b/spec/segment/analytics_spec.rb
@@ -12,6 +12,8 @@ module Segment
 
         it 'errors without user_id or anonymous_id' do
           expect { analytics.track :event => 'event' }.to raise_error(ArgumentError)
+          expect { analytics.track :event => 'event', user_id: ''}.to raise_error(ArgumentError)
+          expect { analytics.track :event => 'event', anonymous_id:''}.to raise_error(ArgumentError)
           expect { analytics.track :event => 'event', user_id: '1234' }.to_not raise_error(ArgumentError)
           expect { analytics.track :event => 'event', anonymous_id: '2345' }.to_not raise_error(ArgumentError)
         end


### PR DESCRIPTION
Events were being swallowed if the user id was an empty string.

This is a fix for issue https://github.com/segmentio/analytics-ruby/issues/243 