### PR TITLE
Mentioning about stubbing actions during tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ RSpec.configure do |config|
 end
 ```
 
+And also to stub actions use `stub: true` along with `test: true` so that it doesn't send any real calls during specs.
 ## License
 
 ```

--- a/lib/segment/analytics/version.rb
+++ b/lib/segment/analytics/version.rb
@@ -1,5 +1,5 @@
 module Segment
   class Analytics
-    VERSION = '2.4.1'
+    VERSION = '2.4.2'
   end
 end


### PR DESCRIPTION
Issue: We have integrated segment events to `slack` and we are getting segment events triggered when the tests run in CI.

From the documentation I thought adding `test: true` while initializing will stub the actions also. But `test: true` will only make the responses available in `test_queue` but still actually send the request through the network.

It would be helpful to mention about stubbing in the `test` section.

Suggestion: The long term goal can be to do the stubbing by default in `test` mode. I can create a pr for that if everyone agrees.