### PR TITLE
Ensure that ssl option is read as expected

### DIFF
--- a/lib/segment/analytics/transport.rb
+++ b/lib/segment/analytics/transport.rb
@@ -19,7 +19,7 @@ module Segment
       def initialize(options = {})
         options[:host] ||= HOST
         options[:port] ||= PORT
-        options[:ssl] ||= SSL
+        options.fetch(:ssl, SSL) == true
         @headers = options[:headers] || HEADERS
         @path = options[:path] || PATH
         @retries = options[:retries] || RETRIES

--- a/spec/segment/analytics/transport_spec.rb
+++ b/spec/segment/analytics/transport_spec.rb
@@ -18,7 +18,7 @@ module Segment
           allow(Net::HTTP).to receive(:new) { net_http }
         end
 
-        it 'sets an initalized Net::HTTP read_timeout' do
+        it 'sets an initalized Net::HTTP use_ssl' do
           expect(net_http).to receive(:use_ssl=)
           described_class.new
         end
@@ -75,6 +75,7 @@ module Segment
               backoff_policy: backoff_policy,
               host: host,
               port: port
+              ssl: false
             }
           end
 
@@ -95,6 +96,7 @@ module Segment
 
           it 'initializes a new Net::HTTP with passed in host and port' do
             expect(Net::HTTP).to receive(:new).with(host, port)
+            expect(Net::HTTP).to receive(:use_ssl).with(false)
             described_class.new(options)
           end
         end


### PR DESCRIPTION
Hello there! I was attempting to mock out the calls to the Segment API for the purposes of load testing and found that if you set the `ssl` option to `false` (which is what you would expect to work), the way that the code was written in the `Transport` class, meant that it was _always_ being set to the default (since `options[:ssl]` evaluates to `false`, using the `||=` operator always flipped it back to `true` aka the default).

This attempts to fix that issue by making it so that setting `ssl` to _anything_ other than `true` will cause it to be set to `false`. I expect that this will more than likely be fine since this isn't really even documented as an option. 