### PR TITLE
Keep worker threads running until exit

### DIFF
--- a/lib/segment/analytics/worker.rb
+++ b/lib/segment/analytics/worker.rb
@@ -38,7 +38,10 @@ module Segment
       #
       def run
         until Thread.current[:should_exit]
-          return if @queue.empty?
+          if @queue.empty?
+            sleep(0.1)
+            next
+          end
 
           @lock.synchronize do
             consume_message_from_queue! until @batch.full? || @queue.empty?


### PR DESCRIPTION
Our (@buildkite's) Datadog profiler reported numerous threads being spawned by this gem in one of our services. We tracked it down to this return statement which causes the worker thread to terminate whenever the queue is empty: https://github.com/segmentio/analytics-ruby/blob/167f59fb0333c3a18df86923f198cf136376a3d1/lib/segment/analytics/client.rb#L173

This creates unnecessary thread churn in long-running applications. Instead of terminating when the queue is empty, the worker thread should remain alive and wait for new messages. The current behavior causes the thread to die and be replaced repeatedly - each time the queue empties and then receives new messages, a new thread must be spawned, which is inefficient, especially when analytics are emitted frequently.

This PR fixes the issue by replacing the early return with a sleep/continue pattern, keeping the worker thread alive during idle periods.