### PR TITLE
Add devbox configuration

### DIFF
--- a/analytics-ruby.gemspec
+++ b/analytics-ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'tzinfo', '~> 1.2'
   spec.add_development_dependency 'activesupport', '~> 5.2.0'
   if RUBY_PLATFORM != 'java'
-    spec.add_development_dependency 'oj', '~> 3.6.2'
+    spec.add_development_dependency 'oj', '~> 3.6'
   end
   spec.add_development_dependency 'rubocop', '~> 1.0'
 end

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.2/.schema/devbox.schema.json",
+  "packages": {
+    "ruby": "3.2",
+    "bundler": "latest",
+    "jq": "latest"
+  },
+  "shell": {
+    "init_hook": [
+      "export PROJECT_ROOT=\"$(git rev-parse --show-toplevel 2>/dev/null || echo $DEVBOX_PROJECT_ROOT)\"",
+      "export GEM_HOME=\"$PROJECT_ROOT/.gem\"",
+      "export PATH=\"$GEM_HOME/bin:$PATH\"",
+      "if [ ! -f \"$PROJECT_ROOT/Gemfile.lock\" ] || [ \"$PROJECT_ROOT/Gemfile\" -nt \"$PROJECT_ROOT/Gemfile.lock\" ]; then echo 'Running bundle install...'; bundle install; fi"
+    ],
+    "scripts": {
+      "ci:install": ["bundle install"],
+      "check": [
+        "devbox run lint",
+        "devbox run test"
+      ],
+      "test": ["bundle exec rake spec"],
+      "lint": ["bundle exec rubocop"],
+      "build": [
+        "rm -f analytics-ruby-*.gem",
+        "gem build ./analytics-ruby.gemspec"
+      ],
+      "install": ["devbox run build", "gem install analytics-ruby-*.gem"],
+      "clean": ["rm -f analytics-ruby-*.gem", "rm -rf .gem", "rm -rf coverage"]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,238 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "bundler@latest": {
+      "last_modified": "2026-06-27T07:37:20Z",
+      "resolved": "github:NixOS/nixpkgs/3d46470bb3030020f7e1361f33514854f5bfa86d#bundler",
+      "source": "devbox-search",
+      "version": "2.7.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8rrxszxdmyx6qka675zmyzd783xa1q0b-bundler-2.7.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8rrxszxdmyx6qka675zmyzd783xa1q0b-bundler-2.7.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/p2799rz5nm17ih6hryz932aawiw76m8k-bundler-2.7.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/p2799rz5nm17ih6hryz932aawiw76m8k-bundler-2.7.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ww85ffrswh2lmmg7fi7jngx34mg5hp5v-bundler-2.7.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ww85ffrswh2lmmg7fi7jngx34mg5hp5v-bundler-2.7.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9vh8syrfd4jnnghghnwfm4gzlm7rgdl3-bundler-2.7.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9vh8syrfd4jnnghghnwfm4gzlm7rgdl3-bundler-2.7.2"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-07-05T19:27:47Z",
+      "resolved": "github:NixOS/nixpkgs/f205b5574fd0cb7da5b702a2da51507b7f4fdd1b?lastModified=1783279667&narHash=sha256-%2FNAkDSsve%2BGNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s%3D"
+    },
+    "jq@latest": {
+      "last_modified": "2026-07-05T19:27:47Z",
+      "resolved": "github:NixOS/nixpkgs/f205b5574fd0cb7da5b702a2da51507b7f4fdd1b#jq",
+      "source": "devbox-search",
+      "version": "1.8.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/n9ri7m7j3l3ggx7ag8xm87cavjvcxycz-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/0l8f1i70kd15qadl45b4fvqlg2j7s5hn-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/phmsnvxjh6rmf7id4wahi3vllbj8fn4s-jq-1.8.1"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/pfp4psnwxs2ygda5sq6sr95x2snn6yjl-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/6va29c6s0v4kqi0zvc5jhn7s31c9i4hd-jq-1.8.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/n9ri7m7j3l3ggx7ag8xm87cavjvcxycz-jq-1.8.1-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/hmwz4mnhiwyy1zyrypbdk6xqrxrpv4jp-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/iy9j5qqv7bkf0fnwh6pddfbk5q93i3nh-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/gkincbg9wkmasrxw36mmyvp08jyhcxxg-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/vh84k872pnn2xavlx9j551056k1h579f-jq-1.8.1-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/cs80rizzqf70hsya9n2h60zj9rf23sr5-jq-1.8.1"
+            }
+          ],
+          "store_path": "/nix/store/hmwz4mnhiwyy1zyrypbdk6xqrxrpv4jp-jq-1.8.1-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/glj1kzrb6jm7x4r5z400mcmja8ws657q-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/vpk901871j7kfmmb20i1vfxh5d8mhim2-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/jb2xgi4gjvzwifzfmf4kzkimbgrhsaav-jq-1.8.1-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/l4i89frkjf4dly7gxwbksrcimcgr2x8f-jq-1.8.1"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/akbah2c4a6xcgpx2l7xqqgfbxgi8anfj-jq-1.8.1-dev"
+            }
+          ],
+          "store_path": "/nix/store/glj1kzrb6jm7x4r5z400mcmja8ws657q-jq-1.8.1-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/q0pj1dw2nr57y6b4pqljklf0hy20alfj-jq-1.8.1-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/d21dmfzxkgpa7jkn5ggr0balzfg0j269-jq-1.8.1-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/3vavalljj18drsycygl361zqz4rryygd-jq-1.8.1-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/nzhykmz9qn2vrb9ki6ddrpipic7rfpfb-jq-1.8.1-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/bzm6nb8fx5p005bygrarn48i6qy1ir3a-jq-1.8.1"
+            }
+          ],
+          "store_path": "/nix/store/q0pj1dw2nr57y6b4pqljklf0hy20alfj-jq-1.8.1-bin"
+        }
+      }
+    },
+    "ruby@3.2": {
+      "last_modified": "2025-10-07T08:41:47Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/bce5fe2bb998488d8e7e7856315f90496723793c#ruby_3_2",
+      "source": "devbox-search",
+      "version": "3.2.9",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/906v7hspcl7qwrl6295d6m20qx09hcrw-ruby-3.2.9",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/3276n55qw6j99lk69njr8s9vznk21gkm-ruby-3.2.9-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/906v7hspcl7qwrl6295d6m20qx09hcrw-ruby-3.2.9"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/js63klsnqk1l6vxn0acdrfcfvsfp23mz-ruby-3.2.9",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/0mcr9a6lqx4gmb4sli5awv3d0f6j0gx1-ruby-3.2.9-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/js63klsnqk1l6vxn0acdrfcfvsfp23mz-ruby-3.2.9"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y949f4l8841r6alnlckpn68jr7h6x5lr-ruby-3.2.9",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/c82kc3krw54s03rh5yfq8wrc3yjybyd3-ruby-3.2.9-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/y949f4l8841r6alnlckpn68jr7h6x5lr-ruby-3.2.9"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/26k4sp4lp7j0m389saxw1hdvi8k4i584-ruby-3.2.9",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/fbslmcvf1q6mpj8w2w6iiwzfqm7kkmaf-ruby-3.2.9-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/26k4sp4lp7j0m389saxw1hdvi8k4i584-ruby-3.2.9"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `devbox.json` with Ruby 3.2, bundler, and jq for reproducible dev/CI environments
- Scripts follow cross-SDK naming conventions (`check`, `test`, `lint`, `build`, `clean`, `ci:install`)
- Init hook auto-runs `bundle install` when Gemfile.lock is stale
- Relaxes `oj` dev dependency from `~> 3.6.2` to `~> 3.6` so native extension compiles with nix/devbox Clang toolchain

## Test plan
- [x] `devbox run -- bundle install` succeeds and resolves all gems
- [x] `devbox run test` passes (1 pre-existing flaky failure unrelated to this change)
- [x] `devbox run lint` runs rubocop (27 pre-existing offenses, none new)
- [ ] Verify devbox shell works on CI runner